### PR TITLE
eyra readme: fix link to example

### DIFF
--- a/eyra/README.md
+++ b/eyra/README.md
@@ -20,7 +20,7 @@ in Rust.
 
 Check out [this hello world example].
 
-[this hello world example]: https://github.com/sunfishcode/c-ward/tree/main/example-crates/eyra
+[this hello world example]: https://github.com/sunfishcode/c-ward/tree/main/example-crates/eyra-example
 
 ## In detail
 


### PR DESCRIPTION
alternative is renaming the directory, to avoid repetition of `example`: `example-crates/eyra-example`