### PR TITLE
Expose the log, env_logger, and experimental-relocate options in eyra.

### DIFF
--- a/c-gull/Cargo.toml
+++ b/c-gull/Cargo.toml
@@ -20,7 +20,6 @@ errno = { version = "0.3.3", default-features = false, optional = true }
 tz-rs = { version = "0.6.11", optional = true }
 printf-compat = { version = "0.1.1", optional = true }
 sync-resolve = { version = "0.3.0", optional = true }
-log = { version = "0.4.14", default-features = false, optional = true }
 rustix = { version = "0.38.10", default-features = false, optional = true, features = ["fs", "itoa", "net", "param", "process", "procfs", "rand", "termios", "thread", "time"] }
 
 [features]
@@ -38,6 +37,16 @@ call-main = ["c-scape/call-main"]
 # `compiler_builtins::mem`) or should it rely on `compiler_builtins`
 # being linked in and providing those definitions?
 define-mem-functions = ["c-scape/define-mem-functions"]
+
+# Enable logging of program and thread startup and shutdown.
+log = ["c-scape/log"]
+
+# Install the `env_logger` crate as a logger.
+env_logger = ["c-scape/env_logger"]
+
+# Enable highly experimental support for performing startup-time relocations,
+# needed to support statically-linked PIE executables.
+experimental-relocate = ["c-scape/experimental-relocate"]
 
 # A feature that pulls in all the individual features needed to use
 # c-gull to write Rust programs completely implemented in Rust.

--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -24,7 +24,6 @@ rustix-futex-sync = { version = "0.1.1", features = ["atomic_usize"] }
 memoffset = "0.9.0"
 realpath-ext = { version = "0.1.0", default-features = false }
 origin = { version = "0.13.0", default-features = false, features = ["thread", "init-fini-arrays"] }
-log = { version = "0.4.14", default-features = false }
 # We use the libc crate for C ABI types and constants, but we don't depend on
 # the actual platform libc.
 libc = { version = "0.2.138", default-features = false }
@@ -53,6 +52,16 @@ call-main = []
 # `compiler_builtins::mem`) or should it rely on `compiler_builtins`
 # being linked in and providing those definitions?
 define-mem-functions = []
+
+# Enable logging of program and thread startup and shutdown.
+log = ["origin/log"]
+
+# Install the `env_logger` crate as a logger.
+env_logger = ["origin/env_logger"]
+
+# Enable highly experimental support for performing startup-time relocations,
+# needed to support statically-linked PIE executables.
+experimental-relocate = ["origin/experimental-relocate"]
 
 # One of the following two features must be enabled:
 

--- a/eyra/Cargo.toml
+++ b/eyra/Cargo.toml
@@ -13,3 +13,16 @@ keywords = ["linux"]
 
 [dependencies]
 libc = { path = "../c-gull", version = "0.14.0", default-features = false, features = ["eyra"], package = "c-gull" }
+
+[features]
+default = []
+
+# Enable logging of program and thread startup and shutdown.
+log = ["libc/log"]
+
+# Install the `env_logger` crate as a logger.
+env_logger = ["libc/env_logger"]
+
+# Enable highly experimental support for performing startup-time relocations,
+# needed to support statically-linked PIE executables.
+experimental-relocate = ["libc/experimental-relocate"]


### PR DESCRIPTION
Eyra users may want to enable origin's log, env_logger, and experimental-relocate features, so make them available.