### PR TITLE
Miscellaneous documentation cleanups.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ platforms, however currently it is only known to be ABI-compatible with
 
 Another libc implementation is [relibc].
 
-[c-scape]: https://github.com/sunfishcode/c-ward/tree/main/c-scape
-[c-gull]: https://github.com/sunfishcode/c-ward/tree/main/c-gull
-[eyra]: https://github.com/sunfishcode/c-ward/tree/main/eyra
+[c-scape]: https://github.com/sunfishcode/c-ward/tree/main/c-scape#readme
+[c-gull]: https://github.com/sunfishcode/c-ward/tree/main/c-gull#readme
+[eyra]: https://github.com/sunfishcode/c-ward/tree/main/eyra#readme
 [relibc]: https://gitlab.redox-os.org/redox-os/relibc/
 [c-scape-example]: https://github.com/sunfishcode/c-ward/blob/main/example-crates/c-scape-example
 [c-gull-example]: https://github.com/sunfishcode/c-ward/blob/main/example-crates/c-gull-example

--- a/c-gull/README.md
+++ b/c-gull/README.md
@@ -38,7 +38,7 @@ c-gull has two main cargo features: "take-charge" and "coexist-with-libc". One
 of these must be enabled.
 
 In "take-charge" mode, c-gull takes charge of the process, handling program
-startup (via origin) providing `malloc` (via c-scape), and other things. This
+startup (via Origin) providing `malloc` (via c-scape), and other things. This
 requires some additional setup; see the [c-gull-example] example crate for
 more details.
 

--- a/c-scape/build.rs
+++ b/c-scape/build.rs
@@ -5,9 +5,9 @@ use std::env::var;
 fn main() {
     let take_charge = var("CARGO_FEATURE_TAKE_CHARGE").is_ok();
 
-    // In take-charge builds, do nothing. In mustang builds, link in empty
-    // versions of libc.a and other libraries, to prevent the linker from
-    // linking in the system versions.
+    // In coexist-with-libc builds, do nothing. But in take-charge builds, add
+    // empty versions of libc.a and other libraries to the linker commandline,
+    // to prevent the linker from finding and linking in the system versions.
     if take_charge {
         for name in &[
             "gcc", "gcc_s", "util", "rt", "pthread", "m", "dl", "c", "crypt", "xnet", "resolv",

--- a/eyra/README.md
+++ b/eyra/README.md
@@ -59,7 +59,7 @@ fn main() {
 ```
 
 With these three steps, this crate prints "Hello, world!". And under the
-covers, it uses [origin] to start and stop the program, [c-ward] to handle
+covers, it uses [Origin] to start and stop the program, [c-ward] to handle
 libc calls from `std`, and [rustix] to do the printing, so it's completely
 implemented in Rust.
 
@@ -94,11 +94,12 @@ of using a custom target and -Z build-std, Eyra just needs users to add
 `-nostartfiles` to their link line, such as via build.rs in the example.
 
 Like Mustang, Eyra currently runs on Rust Nightly on Linux on x86-64, x86,
-aarch64, and riscv64. It aims to support all Linux versions [supported by Rust],
-though at this time it's only tested on relatively recent versions.
+aarch64, and riscv64. It aims to support all Linux versions
+[supported by Rust], though at this time it's only tested on relatively recent
+versions.
 
-[Mustang]: https://github.com/sunfishcode/mustang
-[origin]: https://github.com/sunfishcode/origin
-[c-ward]: https://github.com/sunfishcode/c-ward
-[rustix]: https://github.com/sunfishcode/rustix
+[Mustang]: https://github.com/sunfishcode/mustang#readme
+[Origin]: https://github.com/sunfishcode/origin#readme
+[c-ward]: https://github.com/sunfishcode/c-ward#readme
+[rustix]: https://github.com/sunfishcode/rustix#readme
 [supported by Rust]: https://doc.rust-lang.org/nightly/rustc/platform-support.html


### PR DESCRIPTION
Add `#readme` anchors to repo URLs, capitalize Origin, and fix the comment in c-scape's build.rs to correctly describe the modes it's sensative too.