### PR TITLE
Enable the unwinding crate features needed to support Rust's panic.

### DIFF
--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -33,6 +33,22 @@ rand_core = "0.6.4"
 rand = { version = "0.8.5", default-features = false }
 rustix-dlmalloc = { version = "0.1.0", optional = true }
 
+# Enable "libc" and don't depend on "spin".
+# TODO: Eventually, we should propose a `fde-phdr-rustix` backend option to
+# upstream `unwinding` so that it doesn't need to go through `dl_iterate_phdr`,
+# but `fde-phdr-dl` works for now.
+[target.'cfg(not(target_arch = "arm"))'.dependencies.unwinding]
+version = "0.2.0"
+default-features = false
+features = [
+    "unwinder",
+    "dwarf-expr",
+    "hide-trace",
+    "fde-phdr-dl",
+    "fde-registry",
+    "libc",
+]
+
 [dev-dependencies]
 libc = "0.2.138"
 static_assertions = "1.1.0"

--- a/example-crates/eyra-panic-example/.gitignore
+++ b/example-crates/eyra-panic-example/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/example-crates/eyra-panic-example/Cargo.toml
+++ b/example-crates/eyra-panic-example/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "eyra-panic-example"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+libc = { path = "../../eyra", package = "eyra" }
+
+# This is just an example crate, and not part of the c-ward workspace.
+[workspace]

--- a/example-crates/eyra-panic-example/README.md
+++ b/example-crates/eyra-panic-example/README.md
@@ -1,0 +1,6 @@
+This crate demonstrates the `panic!` mechanism with Eyra.
+
+This is similar to [eyra-example], but does a `panic!` instead of a
+`println!`.
+
+[eyra-example]: https://github.com/sunfishcode/c-ward/tree/main/example-crates/eyra-example/

--- a/example-crates/eyra-panic-example/build.rs
+++ b/example-crates/eyra-panic-example/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    // Pass -nostartfiles to the linker.
+    println!("cargo:rustc-link-arg=-nostartfiles");
+}

--- a/example-crates/eyra-panic-example/src/main.rs
+++ b/example-crates/eyra-panic-example/src/main.rs
@@ -1,0 +1,5 @@
+extern crate libc;
+
+fn main() {
+    panic!("Uh oh!");
+}

--- a/tests/example_crates.rs
+++ b/tests/example_crates.rs
@@ -107,3 +107,15 @@ fn example_crate_eyra_libc_example() {
         None,
     );
 }
+
+#[test]
+fn example_crate_eyra_panic_example() {
+    test_crate(
+        "eyra-panic-example",
+        &[],
+        &[],
+        "",
+        "thread 'main' panicked at src/main.rs:4:5:\nUh oh!\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\n",
+        Some(101)
+    );
+}

--- a/tests/example_crates.rs
+++ b/tests/example_crates.rs
@@ -36,6 +36,13 @@ fn test_crate(
     command.arg("run").arg("--quiet");
     command.arg(&format!("--target={}-unknown-linux-{}", arch, env));
     command.args(args);
+
+    // Special-case "eyra-panic-example" to disable "RUST_BACKTRACE", so that
+    // the stderr message is reproducible.
+    if name == "eyra-panic-example" {
+        command.env_remove("RUST_BACKTRACE");
+    }
+
     command.envs(envs.iter().cloned());
     command.current_dir(format!("example-crates/{}", name));
     let assert = command.assert();


### PR DESCRIPTION
Have c-scape enable the unwinding resolver features that depend on libc, since c-scape provides libc. This includes `fde-phdr-dl`, which allows the Rust panic mechanism to work without any extra help.

And, add an example that does a panic and test that it works.