### PR TITLE
Stop having Eyra try to be a drop-in replacement for libc.

### DIFF
--- a/c-gull/Cargo.toml
+++ b/c-gull/Cargo.toml
@@ -73,9 +73,9 @@ coexist-with-libc = ["c-scape/coexist-with-libc"]
 
 # One of the following two features must be enabled:
 
-# Enable to this to implement `malloc` using Rust's global allocator.
+# Enable this to implement `malloc` using Rust's global allocator.
 malloc-via-rust-global-alloc = ["c-scape/malloc-via-rust-global-alloc"]
 
-# Enable to this to implement `malloc` using third-party crates, which
+# Enable this to implement `malloc` using third-party crates, which
 # is useful to do when using the Rust global allocator is using `malloc`.
 malloc-via-crates = ["c-scape/malloc-via-crates"]

--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -93,9 +93,9 @@ coexist-with-libc = ["origin/libc"]
 
 # One of the following two features must be enabled:
 
-# Enable to this to implement `malloc` using Rust's global allocator.
+# Enable this to implement `malloc` using Rust's global allocator.
 malloc-via-rust-global-alloc = []
 
-# Enable to this to implement `malloc` using third-party crates, which
+# Enable this to implement `malloc` using third-party crates, which
 # is useful to do when using the Rust global allocator is using `malloc`.
 malloc-via-crates = ["rustix-dlmalloc/global"]

--- a/example-crates/eyra-example/src/main.rs
+++ b/example-crates/eyra-example/src/main.rs
@@ -1,4 +1,4 @@
-extern crate libc;
+extern crate eyra;
 
 fn main() {
     println!("Hello, world!");

--- a/example-crates/eyra-libc-example/Cargo.toml
+++ b/example-crates/eyra-libc-example/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-libc = { path = "../../eyra", package = "eyra" }
+eyra = { path = "../../eyra" }
+libc = "0.2.148"
 
 # This is just an example crate, and not part of the c-ward workspace.
 [workspace]

--- a/example-crates/eyra-libc-example/src/main.rs
+++ b/example-crates/eyra-libc-example/src/main.rs
@@ -1,3 +1,5 @@
+extern crate eyra;
+
 fn main() {
     println!("Hello world using Rust `println!`!");
     unsafe { libc::printf("Hello world using libc `printf`!\n\0".as_ptr().cast()); }

--- a/example-crates/eyra-optional-example/.gitignore
+++ b/example-crates/eyra-optional-example/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/example-crates/eyra-optional-example/Cargo.toml
+++ b/example-crates/eyra-optional-example/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
-name = "eyra-example"
+name = "eyra-optional-example"
 version = "0.0.0"
 edition = "2021"
 publish = false
 
 [dependencies]
-eyra = { path = "../../eyra" }
+# Depend on Eyra... optionally!
+eyra = { path = "../../eyra", optional = true }
 
 # This is just an example crate, and not part of the c-ward workspace.
 [workspace]

--- a/example-crates/eyra-optional-example/README.md
+++ b/example-crates/eyra-optional-example/README.md
@@ -1,0 +1,21 @@
+This crate demonstrates the use of Eyra as an optional dependency.
+
+By default, it looks like a normal hello world program. When compiled
+with `--feature=eyra`, it's a hello world program that uses Eyra.
+
+And when compiled with `--features=eyra,eyra/log,eyra/env_logger`, it's
+a hello world program that uses Eyra and can log program startup and
+shutdown:
+
+```console
+$ RUST_LOG=trace cargo +nightly run --quiet --features=eyra,eyra/log,eyra/env_logger
+[TRACE origin::program] Program started
+[TRACE origin::thread] Main Thread[Pid(91601)] initialized
+[TRACE origin::program] Calling `.init_array`-registered function `0x559006f43500(1, 0x7ffd7e5bacd8, 0x7ffd7e5bace8)`
+[TRACE origin::program] Calling `origin_main(1, 0x7ffd7e5bacd8, 0x7ffd7e5bace8)`
+Hello, world!
+[TRACE origin::program] `origin_main` returned `0`
+[TRACE origin::thread] Thread[91601] calling `at_thread_exit`-registered function
+[TRACE origin::thread] Thread[91601] calling `at_thread_exit`-registered function
+[TRACE origin::program] Program exiting
+```

--- a/example-crates/eyra-optional-example/build.rs
+++ b/example-crates/eyra-optional-example/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    // Pass -nostartfiles to the linker, when Eyra is enabled.
+    if std::env::var("CARGO_FEATURE_EYRA").is_ok() {
+        println!("cargo:rustc-link-arg=-nostartfiles");
+    }
+}

--- a/example-crates/eyra-optional-example/src/main.rs
+++ b/example-crates/eyra-optional-example/src/main.rs
@@ -1,0 +1,7 @@
+// Pull in Eyra libraries... optionally!
+#[cfg(feature = "eyra")]
+extern crate eyra;
+
+fn main() {
+    println!("Hello, world!");
+}

--- a/example-crates/eyra-panic-example/Cargo.toml
+++ b/example-crates/eyra-panic-example/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-libc = { path = "../../eyra", package = "eyra" }
+eyra = { path = "../../eyra" }
 
 # This is just an example crate, and not part of the c-ward workspace.
 [workspace]

--- a/example-crates/eyra-panic-example/src/main.rs
+++ b/example-crates/eyra-panic-example/src/main.rs
@@ -1,4 +1,4 @@
-extern crate libc;
+extern crate eyra;
 
 fn main() {
     panic!("Uh oh!");

--- a/eyra/Cargo.toml
+++ b/eyra/Cargo.toml
@@ -12,20 +12,20 @@ edition = "2021"
 keywords = ["linux"]
 
 [dependencies]
-libc = { path = "../c-gull", version = "0.14.5", default-features = false, features = ["eyra"], package = "c-gull" }
+c-gull = { path = "../c-gull", version = "0.14.5", default-features = false, features = ["eyra"] }
 
 [features]
 default = []
 
 # Enable logging of program and thread startup and shutdown.
-log = ["libc/log"]
+log = ["c-gull/log"]
 
 # Install the `env_logger` crate as a logger.
-env_logger = ["libc/env_logger"]
+env_logger = ["c-gull/env_logger"]
 
 # Disable logging.
-max_level_off = ["libc/max_level_off"]
+max_level_off = ["c-gull/max_level_off"]
 
 # Enable highly experimental support for performing startup-time relocations,
 # needed to support statically-linked PIE executables.
-experimental-relocate = ["libc/experimental-relocate"]
+experimental-relocate = ["c-gull/experimental-relocate"]

--- a/eyra/README.md
+++ b/eyra/README.md
@@ -35,18 +35,13 @@ Eyra needs three things. First, a Cargo.toml dependency:
 
 ```toml
 [dependencies]
-libc = { version = "<current-version>", package = "eyra" }
+eyra = "<current-version>"
 ```
 
-This uses the trick of calling the library `libc` while actually using
-`eyra`. This trick isn't necessary, but it sometimes means we can skip
-the next step.
-
-The next step is to mention `libc` somewhere. If there are no other
-mentions of `libc`, adding an `extern crate` is sufficient:
+The next step is to add an `extern crate`:
 
 ```rust
-extern crate libc;
+extern crate eyra;
 
 fn main() {
     println!("Hello, world!");
@@ -78,13 +73,13 @@ as the logger, which can be enabled in Cargo.toml:
 
 ```toml
 [dependencies]
-libc = { version = "<current-version>", package = "eyra", features = ["log", "env_logger"] }
+eyra = { version = "<current-version>", features = ["log", "env_logger"] }
 ```
 
 With this, and setting the `RUST_LOG` environment variable to "trace", the
 hello world program output like this:
 
-```
+```console
 [TRACE origin::program] Program started
 [TRACE origin::thread] Main Thread[Pid(51383)] initialized
 [TRACE origin::program] Calling `.init_array`-registered function `0x55e86306bb80(1, 0x7ffd0f76aad8, 0x7ffd0f76aae8)`

--- a/eyra/src/lib.rs
+++ b/eyra/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![no_std]
 
-extern crate libc;
-
-pub use libc::*;
+/// All the functionality of Eyra is factored out into separate libraries. This
+/// `extern crate` line is needed to ensure that libraries that intercept C
+/// library symbols get linked in.
+extern crate c_gull;

--- a/tests/example_crates.rs
+++ b/tests/example_crates.rs
@@ -126,3 +126,26 @@ fn example_crate_eyra_panic_example() {
         Some(101)
     );
 }
+
+#[test]
+fn example_crate_eyra_optional_example() {
+    // Test the crate in non-Eyra mode.
+    test_crate(
+        "eyra-optional-example",
+        &[],
+        &[],
+        "Hello, world!\n",
+        "",
+        None,
+    );
+
+    // Test the crate in Eyra mode.
+    test_crate(
+        "eyra-optional-example",
+        &["--features=eyra"],
+        &[],
+        "Hello, world!\n",
+        "",
+        None,
+    );
+}


### PR DESCRIPTION
For users already using `libc`, it's inconvenient to add Eyra as a `libc` dependency, and for users not using `libc`, having Eyra be a passthrough isn't useful.

So instead, change the main instructions to use `extern crate eyra` instead of `extern crate libc`, and remove Eyra's `use libc::*;`. This makes it simpler overall, and easier to add Eyra to an existing codebase.

Also, add an example of adding Eyra as an optional dependency.