### PR TITLE
Implement `openpty` and `login_tty`.

### DIFF
--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -32,6 +32,7 @@ rand_pcg = "0.3.1"
 rand_core = "0.6.4"
 rand = { version = "0.8.5", default-features = false }
 rustix-dlmalloc = { version = "0.1.0", optional = true }
+rustix-openpty = "0.1.1"
 
 # Enable "libc" and don't depend on "spin".
 # TODO: Eventually, we should propose a `fde-phdr-rustix` backend option to

--- a/c-scape/src/io/mod.rs
+++ b/c-scape/src/io/mod.rs
@@ -52,8 +52,14 @@ unsafe extern "C" fn ioctl(fd: c_int, request: c_long, mut args: ...) -> c_int {
             libc!(libc::ioctl(fd, libc::TIOCGWINSZ));
             let fd = BorrowedFd::borrow_raw(fd);
             match convert_res(rustix::termios::tcgetwinsize(fd)) {
-                Some(x) => {
-                    args.arg::<*mut rustix::termios::Winsize>().write(x);
+                Some(size) => {
+                    let size = libc::winsize {
+                        ws_row: size.ws_row,
+                        ws_col: size.ws_col,
+                        ws_xpixel: size.ws_xpixel,
+                        ws_ypixel: size.ws_ypixel,
+                    };
+                    args.arg::<*mut libc::winsize>().write(size);
                     0
                 }
                 None => -1,


### PR DESCRIPTION
Use rustix-openpty to implement C-compatible ABIs for `openpty` and `login_tty`.