### PR TITLE
Implement several more socket options, and `sendmsg` and `recvmsg`.

### DIFF
--- a/c-gull/src/lib.rs
+++ b/c-gull/src/lib.rs
@@ -3,8 +3,7 @@
 #![feature(strict_provenance)]
 #![feature(c_variadic)]
 #![feature(sync_unsafe_cell)]
-#![deny(fuzzy_provenance_casts)]
-#![deny(lossy_provenance_casts)]
+#![deny(fuzzy_provenance_casts, lossy_provenance_casts)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate c_scape;

--- a/c-scape/src/fs/sendfile.rs
+++ b/c-scape/src/fs/sendfile.rs
@@ -36,7 +36,7 @@ unsafe extern "C" fn sendfile(
             return -1;
         }
 
-        offset_64 = *offset;
+        offset_64 = (*offset).into();
     }
 
     let res = sendfile64(out_fd, in_fd, &mut offset_64, count);

--- a/c-scape/src/fs/sendfile.rs
+++ b/c-scape/src/fs/sendfile.rs
@@ -15,6 +15,8 @@ unsafe extern "C" fn sendfile(
 ) -> isize {
     libc!(libc::sendfile(out_fd, in_fd, offset, count));
 
+    let mut offset_64: off64_t = 0;
+
     // Check for overflow into off64_t
     if !offset.is_null() {
         if *offset < 0 {
@@ -33,9 +35,10 @@ unsafe extern "C" fn sendfile(
             set_errno(Errno(libc::EINVAL));
             return -1;
         }
+
+        offset_64 = *offset;
     }
 
-    let mut offset_64: off64_t = 0;
     let res = sendfile64(out_fd, in_fd, &mut offset_64, count);
 
     if !offset.is_null() {

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -7,8 +7,7 @@
 #![feature(strict_provenance)]
 #![feature(inline_const)]
 #![feature(sync_unsafe_cell)]
-#![deny(fuzzy_provenance_casts)]
-#![deny(lossy_provenance_casts)]
+#![deny(fuzzy_provenance_casts, lossy_provenance_casts)]
 #![feature(try_blocks)]
 
 // Check that our features were used as we intend.


### PR DESCRIPTION
Implement get/sockopt support for `SO_TCP_USER_TIMEOUT`, `IPV6_RECVTCLASS`, and several others.

And add a simple implementation of `sendmsg` and `recvmsg`, that doesn't yet support ancillary messages, but can do basic data transfers.