### PR TITLE
Avoid depending on `#![feature(try_blocks)]`.

### DIFF
--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -8,7 +8,6 @@
 #![feature(inline_const)]
 #![feature(sync_unsafe_cell)]
 #![deny(fuzzy_provenance_casts, lossy_provenance_casts)]
-#![feature(try_blocks)]
 
 // Check that our features were used as we intend.
 #[cfg(all(feature = "coexist-with-libc", feature = "take-charge"))]


### PR DESCRIPTION
We do depend on nightly for some unstable features, however it's nice to avoid doing that when we can.