### PR TITLE
Implement `flock`, `getrlimit`, and `sync_file_range`.

### DIFF
--- a/c-scape/src/fs/flock.rs
+++ b/c-scape/src/fs/flock.rs
@@ -1,0 +1,31 @@
+use crate::convert_res;
+use libc::c_int;
+use rustix::fd::BorrowedFd;
+use rustix::fs::FlockOperation;
+
+#[no_mangle]
+unsafe extern "C" fn flock(fd: c_int, operation: c_int) -> c_int {
+    libc!(libc::flock(fd, operation));
+
+    let fd = BorrowedFd::borrow_raw(fd);
+    let operation = if operation == libc::LOCK_SH {
+        FlockOperation::LockShared
+    } else if operation == libc::LOCK_EX {
+        FlockOperation::LockExclusive
+    } else if operation == libc::LOCK_UN {
+        FlockOperation::Unlock
+    } else if operation == libc::LOCK_SH | libc::LOCK_NB {
+        FlockOperation::NonBlockingLockShared
+    } else if operation == libc::LOCK_EX | libc::LOCK_NB {
+        FlockOperation::NonBlockingLockExclusive
+    } else if operation == libc::LOCK_UN | libc::LOCK_NB {
+        FlockOperation::NonBlockingUnlock
+    } else {
+        unreachable!()
+    };
+
+    match convert_res(rustix::fs::flock(fd, operation)) {
+        Some(()) => 0,
+        None => -1,
+    }
+}

--- a/c-scape/src/fs/mod.rs
+++ b/c-scape/src/fs/mod.rs
@@ -4,6 +4,7 @@ mod chmod;
 mod dir;
 mod fadvise;
 mod fcntl;
+mod flock;
 mod inotify;
 mod link;
 mod lseek;

--- a/c-scape/src/process/rlimit.rs
+++ b/c-scape/src/process/rlimit.rs
@@ -3,6 +3,36 @@ use libc::{c_int, c_uint, RLIM64_INFINITY, RLIM_INFINITY};
 use rustix::process::{Pid, Resource, Rlimit};
 
 #[no_mangle]
+unsafe extern "C" fn getrlimit(resource: c_uint, old_limit: *mut libc::rlimit) -> c_int {
+    libc!(libc::getrlimit(resource, old_limit));
+
+    let resource = match resource_to_rustix(resource) {
+        Some(resource) => resource,
+        None => return -1,
+    };
+    let limit = rustix::process::getrlimit(resource);
+    if !old_limit.is_null() {
+        *old_limit = rustix_to_rlimit(limit);
+    }
+    0
+}
+
+#[no_mangle]
+unsafe extern "C" fn getrlimit64(resource: c_uint, old_limit: *mut libc::rlimit64) -> c_int {
+    libc!(libc::getrlimit64(resource, old_limit));
+
+    let resource = match resource_to_rustix(resource) {
+        Some(resource) => resource,
+        None => return -1,
+    };
+    let limit = rustix::process::getrlimit(resource);
+    if !old_limit.is_null() {
+        *old_limit = rustix_to_rlimit64(limit);
+    }
+    0
+}
+
+#[no_mangle]
 unsafe extern "C" fn prlimit(
     pid: libc::pid_t,
     resource: c_uint,


### PR DESCRIPTION
rustix doesn't have `sync_file_range` yet, but `fdatasync` should suffice as a temporary measure.