### PR TITLE
Miscellaneous cleanups.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "An implementation of libc written in Rust"
 license = "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
 repository = "https://github.com/sunfishcode/c-ward"
 edition = "2021"
-exclude = ["/.github"]
+exclude = ["/.github", "ci"]
 publish = false
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -22,9 +22,8 @@ It consists of two crates:
  - [c-gull], which pulls in c-scape and additionally provides features
    using `std`.
 
-It is a goal of c-ward to be a C ABI layer on top of Rust-idomatic
-libraries, rather than to have significant implementation code of
-its own.
+It is a goal of c-ward to be a C ABI layer on top of Rust-idomatic libraries,
+rather than to have significant implementation code of its own.
 
 In theory c-ward could be extended to be ABI-compatible with different
 platforms, however currently it is only known to be ABI-compatible with

--- a/c-gull/Cargo.toml
+++ b/c-gull/Cargo.toml
@@ -41,6 +41,9 @@ define-mem-functions = ["c-scape/define-mem-functions"]
 # Enable logging of program and thread startup and shutdown.
 log = ["c-scape/log"]
 
+# Install `atomic_dbg::log` as a logger.
+atomic-dbg-logger = ["c-scape/atomic-dbg-logger"]
+
 # Install the `env_logger` crate as a logger.
 env_logger = ["c-scape/env_logger"]
 

--- a/c-gull/src/use_libc.rs
+++ b/c-gull/src/use_libc.rs
@@ -35,8 +35,8 @@ macro_rules! checked_cast {
 /// ```no_run
 /// #[no_mangle]
 /// unsafe extern "C" fn strlen(s: *const c_char) -> usize {
-///    libc!(libc::strlen(s));
-///    // ...
+///     libc!(libc::strlen(s));
+///     // ...
 /// }
 /// ```
 ///

--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -34,6 +34,10 @@ rand = { version = "0.8.5", default-features = false }
 rustix-dlmalloc = { version = "0.1.0", optional = true }
 rustix-openpty = "0.1.1"
 
+# Special dependencies used in rustc-dep-of-std mode.
+core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
+alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
+
 # Enable "libc" and don't depend on "spin".
 # TODO: Eventually, we should propose a `fde-phdr-rustix` backend option to
 # upstream `unwinding` so that it doesn't need to go through `dl_iterate_phdr`,
@@ -73,6 +77,9 @@ define-mem-functions = []
 # Enable logging of program and thread startup and shutdown.
 log = ["origin/log"]
 
+# Install `atomic_dbg::log` as a logger.
+atomic-dbg-logger = ["origin/atomic-dbg-logger"]
+
 # Install the `env_logger` crate as a logger.
 env_logger = ["origin/env_logger"]
 
@@ -86,7 +93,7 @@ experimental-relocate = ["origin/experimental-relocate"]
 # One of the following two features must be enabled:
 
 # Enable this to tell c-scape to take control of the process.
-take-charge = ["origin/origin-start", "origin/origin-thread", "origin/origin-signal", "origin/origin-program"]
+take-charge = ["origin/origin-start", "origin/origin-thread", "origin/origin-signal"]
 
 # Enable this to tell c-scape to let a libc be in control of
 # the process.
@@ -100,3 +107,10 @@ malloc-via-rust-global-alloc = []
 # Enable this to implement `malloc` using third-party crates, which
 # is useful to do when using the Rust global allocator is using `malloc`.
 malloc-via-crates = ["rustix-dlmalloc/global"]
+
+# Special feature for use when c-scape is a dependency of std.
+rustc-dep-of-std = [
+    "dep:core",
+    "dep:alloc",
+    "rustix/rustc-dep-of-std",
+]

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -108,15 +108,18 @@ unsafe impl Send for UnsafeSendSyncVoidStar {}
 #[cfg(feature = "take-charge")]
 unsafe impl Sync for UnsafeSendSyncVoidStar {}
 
-/// Adapt from origin's `origin_main` to a C ABI `main`.
+/// This function is called by Origin.
+///
+/// SAFETY: `argc`, `argv`, and `envp` describe incoming program
+/// command-line arguments and environment variables.
 #[cfg(feature = "take-charge")]
 #[cfg(feature = "call-main")]
 #[no_mangle]
-fn origin_main(argc: usize, argv: *mut *mut u8, envp: *mut *mut u8) -> i32 {
+unsafe fn origin_main(argc: usize, argv: *mut *mut u8, envp: *mut *mut u8) -> i32 {
     extern "C" {
         fn main(argc: i32, argv: *const *const u8, envp: *const *const u8) -> i32;
     }
-    unsafe { main(argc as _, argv as _, envp as _) }
+    main(argc as _, argv as _, envp as _)
 }
 
 // utilities

--- a/c-scape/src/use_libc.rs
+++ b/c-scape/src/use_libc.rs
@@ -35,8 +35,8 @@ macro_rules! checked_cast {
 /// ```no_run
 /// #[no_mangle]
 /// unsafe extern "C" fn strlen(s: *const c_char) -> usize {
-///    libc!(libc::strlen(s));
-///    // ...
+///     libc!(libc::strlen(s));
+///     // ...
 /// }
 /// ```
 ///


### PR DESCRIPTION
 - Exclude the "ci" directory from the published crate.
 - Expose `atomic-dbg-logger` as a logging option.
 - Tidy up comments.
 - Improve rustc-dep-of-std mode.