### PR TITLE
Fix some bugs turned up in libc-testsuite.

### DIFF
--- a/c-scape/src/mem/ntbs.rs
+++ b/c-scape/src/mem/ntbs.rs
@@ -69,9 +69,12 @@ unsafe extern "C" fn strchr(s: *const c_char, c: c_int) -> *mut c_char {
     libc!(libc::strchr(s, c));
 
     let mut s = s as *mut c_char;
-    while *s != NUL {
+    loop {
         if *s == c as _ {
             return s;
+        }
+        if *s == NUL {
+            break;
         }
         s = s.add(1);
     }
@@ -230,10 +233,10 @@ unsafe extern "C" fn strpbrk(s: *const c_char, m: *const c_char) -> *mut c_char 
     let s = s.add(strcspn(s, m)) as *mut _;
 
     if *s != NUL {
-        return ptr::null_mut();
+        return s;
     }
 
-    s
+    ptr::null_mut()
 }
 
 #[no_mangle]
@@ -312,7 +315,7 @@ unsafe extern "C" fn strtok_r(
     let t = s.add(strcspn(s, m));
     if *t != NUL {
         *t = NUL;
-        *p = t;
+        *p = t.add(1);
     } else {
         *p = ptr::null_mut();
     }

--- a/c-scape/src/thread/key.rs
+++ b/c-scape/src/thread/key.rs
@@ -103,7 +103,7 @@ unsafe extern "C" fn pthread_setspecific(key: libc::pthread_key_t, value: *const
 
                         // Call the destructor with the old
                         // data, before we set it to null.
-                        dtor(value as *mut _);
+                        dtor(data as *mut _);
                     }
                 }
 
@@ -151,6 +151,7 @@ unsafe extern "C" fn pthread_key_create(
                     panic!("detected epoch counter overflow");
                 }
                 next_key = index as libc::pthread_key_t;
+                break;
             }
         }
 
@@ -163,6 +164,7 @@ unsafe extern "C" fn pthread_key_create(
 
     // We have to `unwrap_or` the dtor because `None` is reserved for signifying
     // that the key is not allocated.
+    *key = next_key;
     key_data.destructors[next_key as usize] = Some(dtor.unwrap_or(empty_dtor));
 
     0

--- a/c-scape/src/thread/mod.rs
+++ b/c-scape/src/thread/mod.rs
@@ -449,11 +449,16 @@ unsafe extern "C" fn pthread_cond_init(
         checked_cast!(cond),
         checked_cast!(attr)
     ));
+    let attr = if attr.is_null() {
+        PthreadCondattrT::default()
+    } else {
+        ptr::read(attr)
+    };
     ptr::write(
         cond,
         PthreadCondT {
             inner: RawCondvar::new(),
-            attr: ptr::read(attr),
+            attr,
             pad: [0_u8;
                 SIZEOF_PTHREAD_COND_T - size_of::<RawCondvar>() - size_of::<PthreadCondattrT>()],
         },


### PR DESCRIPTION
I was doing some experiments with a modified version of libc-testsuite and found some miscellaneous bugs in strchr, strpbrk, strtok, pthread_setspecific, and pthread_cond_init.