### PR TITLE
Fix LTO compatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,25 @@ platforms, however currently it is only known to be ABI-compatible with
 
 Another libc implementation is [relibc].
 
+## Where's the `#![no_builtins]`?
+
+Normally, a libc implementation would use `#[no_builtins]` to prevent compilers
+from noticing the the bodies of libc functions implement the semantics of libc
+functions and replacing them with calls, which effectively makes them uselessly
+recursive calls to themselves.
+
+However, `#[no_builtins]` is too pessimistic, because we don't need to disable
+all pattern matching, just these specific cases. And, `#[no_builtins]`
+[interferes with LTO optimization].
+
+So instead, c-scape and c-gull are just careful to avoid open-coding functions
+which are known to get pattern-matched into builtins, by just calling the
+`compiler_builtins` implementations directly themselves. This way, we can avoid
+using `#![no_builtins]`.
+
 [c-scape]: https://github.com/sunfishcode/c-ward/tree/main/c-scape#readme
 [c-gull]: https://github.com/sunfishcode/c-ward/tree/main/c-gull#readme
 [relibc]: https://gitlab.redox-os.org/redox-os/relibc/
 [c-scape-example]: https://github.com/sunfishcode/c-ward/blob/main/example-crates/c-scape-example
 [c-gull-example]: https://github.com/sunfishcode/c-ward/blob/main/example-crates/c-gull-example
+[interferes with LTO optimization]: https://github.com/rust-lang/rust/blob/72e29da3eccd3e4c1fb2c581fa33216db50fcc93/compiler/rustc_codegen_ssa/src/back/link.rs#L1264

--- a/c-gull/src/lib.rs
+++ b/c-gull/src/lib.rs
@@ -1,5 +1,4 @@
 #![doc = include_str!("../README.md")]
-#![no_builtins] // don't let LLVM optimize our `memcpy` into a `memcpy` call
 #![feature(strict_provenance)]
 #![feature(c_variadic)]
 #![feature(sync_unsafe_cell)]

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -1,6 +1,5 @@
 #![doc = include_str!("../README.md")]
 #![no_std]
-#![no_builtins] // don't let LLVM optimize our `memcpy` into a `memcpy` call
 #![feature(thread_local)] // for `__errno_location`
 #![feature(c_variadic)] // for `ioctl` etc.
 #![feature(rustc_private)] // for compiler-builtins

--- a/example-crates/c-gull-lto/.gitignore
+++ b/example-crates/c-gull-lto/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/example-crates/c-gull-lto/Cargo.toml
+++ b/example-crates/c-gull-lto/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "c-gull-lto"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+libc = { path = "../../c-gull", default-features = false, features = ["take-charge", "std", "thread", "call-main", "malloc-via-crates", "define-mem-functions"], package = "c-gull" }
+
+# Enable LTO.
+[profile.release]
+lto = true
+
+# This is just an example crate, and not part of the c-ward workspace.
+[workspace]

--- a/example-crates/c-gull-lto/README.md
+++ b/example-crates/c-gull-lto/README.md
@@ -1,0 +1,5 @@
+This crate demonstrates the use of c-gull with LTO.
+
+It's the same as [c-gull-example], but enables LTO in Cargo.toml.
+
+[c-gull-example]: https://github.com/sunfishcode/c-ward/tree/main/example-crates/c-gull-example#readme

--- a/example-crates/c-gull-lto/build.rs
+++ b/example-crates/c-gull-lto/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    // Pass -nostartfiles to the linker.
+    println!("cargo:rustc-link-arg=-nostartfiles");
+}

--- a/example-crates/c-gull-lto/src/main.rs
+++ b/example-crates/c-gull-lto/src/main.rs
@@ -1,0 +1,13 @@
+//! A simple example using "take-charge" mode. Origin starts the process,
+//! calls `origin_main`, which transfers control to c-scape which calls the
+//! C-ABI-compatible extern `main` definition, which transfers control to
+//! the Rust std initialization code, which calls the user `main` function
+//! here.
+//!
+//! The end result is that we get all of `std`, using c-gull to implement
+//! all the libc calls underneath, and we can write totally normal Rust code.
+
+fn main() {
+    println!("Hello world using Rust `println!`!");
+    unsafe { libc::printf("Hello world using libc `printf`!\n\0".as_ptr().cast()); }
+}

--- a/tests/example_crates.rs
+++ b/tests/example_crates.rs
@@ -76,6 +76,18 @@ fn example_crate_c_gull_example() {
 }
 
 #[test]
+fn example_crate_c_gull_lto() {
+    test_crate(
+        "c-gull-lto",
+        &["--release"],
+        &[],
+        "Hello world using Rust `println!`!\nHello world using libc `printf`!\n",
+        "",
+        None,
+    );
+}
+
+#[test]
 fn example_crate_custom_allocator() {
     test_crate(
         "custom-allocator",


### PR DESCRIPTION
`#![no_builtins]` [interferes with LTO], so stop using it. For `memcpy` etc., we'll just be careful to always call `compiler_builtins` instead of using plain code that could be pattern-matched.

If we ever want to stop using `compiler_builtins`, we can use [`black_box`] to prevent compilers from pattern-matching.

[interferes with LTO]: https://github.com/rust-lang/rust/blob/72e29da3eccd3e4c1fb2c581fa33216db50fcc93/compiler/rustc_codegen_ssa/src/back/link.rs#L1264
[`black_box`]: https://doc.rust-lang.org/stable/core/hint/fn.black_box.html