### PR TITLE
Tidy up code to use `rustix::cstr`.

### DIFF
--- a/c-gull/src/resolve.rs
+++ b/c-gull/src/resolve.rs
@@ -4,9 +4,10 @@ use core::ptr::null_mut;
 
 use errno::{set_errno, Errno};
 use libc::{c_char, c_int};
-use rustix::net::{SocketAddrAny, SocketAddrStorage, SocketType};
-
-use rustix::net::{IpAddr, SocketAddrV4, SocketAddrV6};
+use rustix::cstr;
+use rustix::net::{
+    IpAddr, SocketAddrAny, SocketAddrStorage, SocketAddrV4, SocketAddrV6, SocketType,
+};
 use sync_resolve::resolve_host;
 
 extern crate alloc;
@@ -130,12 +131,11 @@ unsafe extern "C" fn gai_strerror(errcode: c_int) -> *const c_char {
     libc!(libc::gai_strerror(errcode));
 
     match errcode {
-        libc::EAI_NONAME => &b"Name does not resolve\0"[..],
-        libc::EAI_SYSTEM => &b"System error\0"[..],
+        libc::EAI_NONAME => cstr!("Name does not resolve"),
+        libc::EAI_SYSTEM => cstr!("System error"),
         _ => panic!("unrecognized gai_strerror {:?}", errcode),
     }
     .as_ptr()
-    .cast()
 }
 
 #[no_mangle]

--- a/c-scape/src/glibc_versioning.rs
+++ b/c-scape/src/glibc_versioning.rs
@@ -1,4 +1,5 @@
 use libc::c_char;
+use rustix::cstr;
 
 #[no_mangle]
 unsafe extern "C" fn gnu_get_libc_version() -> *const c_char {
@@ -7,5 +8,5 @@ unsafe extern "C" fn gnu_get_libc_version() -> *const c_char {
     // which is a glibc version where `posix_spawn` doesn't handle `ENOENT`
     // as std wants, so it uses `fork`+`exec` instead, since we don't yet
     // implement `posix_spawn`.
-    b"2.23\0".as_ptr().cast()
+    cstr!("2.23").as_ptr()
 }

--- a/c-scape/src/process_.rs
+++ b/c-scape/src/process_.rs
@@ -7,6 +7,7 @@ use core::ptr::null_mut;
 #[cfg(feature = "take-charge")]
 use libc::c_ulong;
 use libc::{c_char, c_int, c_long, c_void};
+use rustix::cstr;
 
 #[no_mangle]
 unsafe extern "C" fn sysconf(name: c_int) -> c_long {
@@ -97,7 +98,7 @@ unsafe extern "C" fn dl_iterate_phdr(
     let (phdr, _phent, phnum) = rustix::runtime::exe_phdrs();
     let mut info = libc::dl_phdr_info {
         dlpi_addr: (&mut __executable_start as *mut c_void).expose_addr() as _,
-        dlpi_name: b"/proc/self/exe\0".as_ptr().cast(),
+        dlpi_name: cstr!("/proc/self/exe").as_ptr(),
         dlpi_phdr: phdr.cast(),
         dlpi_phnum: phnum.try_into().unwrap(),
         ..zeroed()


### PR DESCRIPTION
This replaces manual NUL terminators.