### PR TITLE
Don't define `exit`, `atexit`, etc. in coexist-with-libc mode.

### DIFF
--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -75,6 +75,7 @@ mod thread;
 mod atoi;
 mod errno_;
 mod exec;
+#[cfg(feature = "take-charge")]
 mod exit;
 mod glibc_versioning;
 mod nss;

--- a/example-crates/libc-replacement/src/main.rs
+++ b/example-crates/libc-replacement/src/main.rs
@@ -1,4 +1,9 @@
 fn main() {
     println!("Hello, world! uid={}", unsafe { libc::getuid() });
     unsafe { libc::printf("Hello world with printf! gid=%u\n\0".as_ptr().cast(), libc::getgid()); }
+    unsafe { libc::atexit(atexit_func); }
+}
+
+extern "C" fn atexit_func() {
+    unsafe { libc::printf("Hello world from `atexit_func`\n\0".as_ptr().cast()); }
 }

--- a/tests/example_crates.rs
+++ b/tests/example_crates.rs
@@ -55,7 +55,7 @@ fn example_crate_libc_replacement() {
         let uid = unsafe { libc::getuid() };
         let gid = unsafe { libc::getgid() };
         format!(
-            "Hello, world! uid={}\nHello world with printf! gid={}\n",
+            "Hello, world! uid={}\nHello world with printf! gid={}\nHello world from `atexit_func`\n",
             uid, gid
         )
     });


### PR DESCRIPTION
When usingi libc, `origin::program::at_exit` is implemented in terms of `libc::atexit`, so don't have c-scape define `atexit` when in coexist-with-libc mode.