### PR TITLE
Use `getent` for DNS resolution instead of sync-resolve.

### DIFF
--- a/c-gull/Cargo.toml
+++ b/c-gull/Cargo.toml
@@ -19,13 +19,12 @@ c-scape = { path = "../c-scape", version = "0.15.11", default-features = false }
 errno = { version = "0.3.3", default-features = false, optional = true }
 tz-rs = { version = "0.6.11", default-features = false, optional = true }
 printf-compat = { version = "0.1.1", optional = true }
-sync-resolve = { version = "0.3.0", optional = true }
 rustix = { version = "0.38.10", default-features = false, optional = true, features = ["fs", "itoa", "net", "param", "process", "procfs", "rand", "termios", "thread", "time"] }
 
 [features]
 default = ["thread", "std", "coexist-with-libc"]
 thread = ["c-scape/thread"]
-std = ["c-scape/std", "rustix/std", "printf-compat/std", "tz-rs/std", "errno/std", "sync-resolve"]
+std = ["c-scape/std", "rustix/std", "printf-compat/std", "tz-rs/std", "errno/std"]
 
 # In "take-charge" mode, this enables code in c-scape to define the
 # `origin_start` function documented [here] and call a C ABI-compatible

--- a/c-gull/README.md
+++ b/c-gull/README.md
@@ -17,8 +17,7 @@ c-gull is a libc implementation. It is an implementation of the ABI described
 by the [libc] crate.
 
 It is implemented in terms of crates written in Rust, such as [c-scape],
-[rustix], [origin], [sync-resolve], [libm], [realpath-ext], [tz-rs], and
-[printf-compat].
+[rustix], [origin], [libm], [realpath-ext], [tz-rs], and [printf-compat].
 
 Currently it only supports `*-*-linux-gnu` ABIs, though other ABIs could be
 added in the future. And currently this mostly focused on features needed by
@@ -59,7 +58,6 @@ things. See the [libc-replacement example] for more details.
 [c-scape]: https://crates.io/crates/c-scape
 [rustix]: https://crates.io/crates/rustix
 [origin]: https://crates.io/crates/origin
-[sync-resolve]: https://crates.io/crates/sync-resolve
 [libm]: https://crates.io/crates/libm
 [libc]: https://crates.io/crates/libc
 [realpath-ext]: https://crates.io/crates/realpath-ext

--- a/c-gull/src/nss.rs
+++ b/c-gull/src/nss.rs
@@ -247,7 +247,7 @@ unsafe fn getgr_r(
     match output.status.code() {
         Some(0) => {}
         Some(2) => {
-            // The username was not found.
+            // The groupname was not found.
             *result = null_mut();
             return 0;
         }
@@ -591,7 +591,7 @@ unsafe extern "C" fn getgrouplist(
         None => return -1,
     };
 
-    let mut parts = stdout.split_whitespace();
+    let mut parts = stdout.split_ascii_whitespace();
     match parts.next() {
         Some(part) => {
             if part != user {

--- a/example-crates/dns/.gitignore
+++ b/example-crates/dns/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/example-crates/dns/Cargo.toml
+++ b/example-crates/dns/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "dns"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+libc = { path = "../../c-gull", default-features = false, features = ["take-charge", "std", "thread", "call-main", "malloc-via-crates", "define-mem-functions"], package = "c-gull" }
+
+# This is just an example crate, and not part of the c-ward workspace.
+[workspace]

--- a/example-crates/dns/README.md
+++ b/example-crates/dns/README.md
@@ -1,0 +1,4 @@
+This crate demonstrates the use of c-gull's DNS resolver.
+
+c-gull parses the output of the `getent` command, so its behavior should
+respect the system DNS and NSS configuration, without using `dlopen`.

--- a/example-crates/dns/build.rs
+++ b/example-crates/dns/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    // Pass -nostartfiles to the linker.
+    println!("cargo:rustc-link-arg=-nostartfiles");
+}

--- a/example-crates/dns/src/main.rs
+++ b/example-crates/dns/src/main.rs
@@ -1,0 +1,17 @@
+//! A simple DNS client.
+
+extern crate libc;
+
+use std::net::ToSocketAddrs;
+
+fn main() {
+    let mut args = std::env::args();
+    let _ = args.next();
+    for arg in args {
+        println!("resolving '{}:", arg);
+        let addrs_iter = arg.to_socket_addrs().unwrap();
+        for addr in addrs_iter {
+            println!(" - {}", addr);
+        }
+    }
+}

--- a/tests/example_crates.rs
+++ b/tests/example_crates.rs
@@ -103,3 +103,15 @@ fn example_crate_custom_allocator() {
 fn example_crate_c_scape_example() {
     test_crate("c-scape-example", &[], &[], "Hello, world!\n", "", None);
 }
+
+#[test]
+fn example_crate_dns() {
+    test_crate(
+        "dns",
+        &["localhost:80"],
+        &[],
+        "resolving 'localhost:80:\n - [::1]:80\n - 127.0.0.1:80\n",
+        "",
+        None,
+    );
+}


### PR DESCRIPTION
Use the `getent ahosts` command to implement `getaddrinfo` instead of the sync-resolve crate, which is not actively maintained. This also follows the host DNS and NSS configuration.