### PR TITLE
Miscellaneous code cleanups

### DIFF
--- a/c-gull/src/termios_.rs
+++ b/c-gull/src/termios_.rs
@@ -24,7 +24,7 @@ unsafe extern "C" fn ttyname(fd: c_int) -> *mut c_char {
     };
     (*storage) = Some(name);
 
-    (*storage).as_ref().unwrap().as_ptr() as *mut c_char
+    (*storage).as_ref().unwrap().as_ptr().cast_mut()
 }
 
 #[no_mangle]

--- a/c-gull/src/time.rs
+++ b/c-gull/src/time.rs
@@ -393,17 +393,17 @@ unsafe fn set_timezone(
     dst: Option<&LocalTimeType>,
 ) {
     guard.0 = Some(CString::new(std.time_zone_designation()).unwrap());
-    tzname.0[0] = guard.0.as_ref().unwrap().as_ptr() as *mut c_char;
+    tzname.0[0] = guard.0.as_ref().unwrap().as_ptr().cast_mut();
 
     match dst {
         Some(dst) => {
             guard.1 = Some(CString::new(dst.time_zone_designation()).unwrap());
-            tzname.0[1] = guard.1.as_ref().unwrap().as_ptr() as *mut c_char;
+            tzname.0[1] = guard.1.as_ref().unwrap().as_ptr().cast_mut();
             daylight = 1;
         }
         None => {
             guard.1 = None;
-            tzname.0[1] = guard.0.as_ref().unwrap().as_ptr() as *mut c_char;
+            tzname.0[1] = guard.0.as_ref().unwrap().as_ptr().cast_mut();
             daylight = 0;
         }
     }

--- a/c-scape/src/env/mod.rs
+++ b/c-scape/src/env/mod.rs
@@ -65,7 +65,7 @@ unsafe fn sync_environ(environ_vecs: &mut EnvironVecs) {
                 break;
             }
             let owned = CStr::from_ptr(env).to_owned();
-            vecs.ptrs.push(owned.as_ptr() as *mut c_char);
+            vecs.ptrs.push(owned.as_ptr().cast_mut());
             vecs.allocs.push(owned);
             ptr = ptr.add(1);
         }
@@ -124,7 +124,7 @@ unsafe extern "C" fn setenv(key: *const c_char, value: *const c_char, overwrite:
             // We found it.
             if overwrite != 0 {
                 let index = ptr.offset_from(environ) as usize;
-                environ_vecs.ptrs[index] = owned.as_ptr() as *mut c_char;
+                environ_vecs.ptrs[index] = owned.as_ptr().cast_mut();
                 environ_vecs.allocs[index] = owned;
             }
             return 0;
@@ -134,7 +134,7 @@ unsafe extern "C" fn setenv(key: *const c_char, value: *const c_char, overwrite:
 
     // We didn't find the key; append it.
     environ_vecs.ptrs.pop();
-    environ_vecs.ptrs.push(owned.as_ptr() as *mut c_char);
+    environ_vecs.ptrs.push(owned.as_ptr().cast_mut());
     environ_vecs.ptrs.push(null_mut());
     environ_vecs.allocs.push(owned);
     environ = environ_vecs.ptrs.as_mut_ptr();

--- a/c-scape/src/fs/stat.rs
+++ b/c-scape/src/fs/stat.rs
@@ -1,7 +1,7 @@
 use core::convert::TryInto;
 use core::ffi::CStr;
 use core::mem::size_of_val;
-use core::ptr::copy_nonoverlapping;
+use core::ptr::{addr_of, addr_of_mut, copy_nonoverlapping};
 use errno::{set_errno, Errno};
 use libc::{c_char, c_int, time_t};
 use rustix::fd::BorrowedFd;
@@ -190,8 +190,8 @@ unsafe extern "C" fn statfs(path: *const c_char, stat_: *mut libc::statfs) -> c_
                 // but understanding is not required for the job here.
                 assert_eq!(size_of_val(&r.f_fsid), size_of_val(&converted.f_fsid));
                 copy_nonoverlapping(
-                    &r.f_fsid as *const _ as *const u8,
-                    &mut converted.f_fsid as *mut _ as *mut u8,
+                    addr_of!(r.f_fsid).cast::<u8>(),
+                    addr_of_mut!(converted.f_fsid).cast::<u8>(),
                     size_of_val(&r.f_fsid),
                 );
 

--- a/c-scape/src/fs/utime.rs
+++ b/c-scape/src/fs/utime.rs
@@ -35,7 +35,7 @@ unsafe fn timestamp_from_timespecs(times: *const [libc::timespec; 2]) -> Timesta
 unsafe extern "C" fn futimens(fd: c_int, times: *const libc::timespec) -> c_int {
     libc!(libc::futimens(fd, times));
 
-    let times = times as *const [libc::timespec; 2];
+    let times = times.cast::<[libc::timespec; 2]>();
 
     match convert_res(rustix::fs::futimens(
         BorrowedFd::borrow_raw(fd),
@@ -55,7 +55,7 @@ unsafe extern "C" fn utimensat(
 ) -> c_int {
     libc!(libc::utimensat(fd, path, times, flag));
 
-    let times = times as *const [libc::timespec; 2];
+    let times = times.cast::<[libc::timespec; 2]>();
     let flags = AtFlags::from_bits(flag as _).unwrap();
 
     match convert_res(rustix::fs::utimensat(
@@ -75,7 +75,7 @@ unsafe extern "C" fn utimes(path: *const c_char, times: *const libc::timeval) ->
 
     let mut arr: [libc::timespec; 2] = core::mem::zeroed();
 
-    let times = times as *const [libc::timeval; 2];
+    let times = times.cast::<[libc::timeval; 2]>();
     if !times.is_null() {
         for i in 0..2 {
             arr[i].tv_sec = (*times)[i].tv_sec;
@@ -108,7 +108,7 @@ unsafe extern "C" fn lutimes(path: *const c_char, times: *const libc::timeval) -
 
     let mut arr: [libc::timespec; 2] = core::mem::zeroed();
 
-    let times = times as *const [libc::timeval; 2];
+    let times = times.cast::<[libc::timeval; 2]>();
     if !times.is_null() {
         for i in 0..2 {
             arr[i].tv_sec = (*times)[i].tv_sec;
@@ -141,7 +141,7 @@ unsafe extern "C" fn futimes(fd: c_int, times: *const libc::timeval) -> c_int {
 
     let mut arr: [libc::timespec; 2] = core::mem::zeroed();
 
-    let times = times as *const [libc::timeval; 2];
+    let times = times.cast::<[libc::timeval; 2]>();
     if !times.is_null() {
         for i in 0..2 {
             arr[i].tv_sec = (*times)[i].tv_sec;

--- a/c-scape/src/io/read.rs
+++ b/c-scape/src/io/read.rs
@@ -42,7 +42,7 @@ unsafe extern "C" fn readv(fd: c_int, iov: *const iovec, iovcnt: c_int) -> isize
     // cast away the `const` here.
     match convert_res(rustix::io::readv(
         BorrowedFd::borrow_raw(fd),
-        slice::from_raw_parts_mut(iov as *mut _, iovcnt as usize),
+        slice::from_raw_parts_mut(iov.cast_mut(), iovcnt as usize),
     )) {
         Some(nread) => nread as isize,
         None => -1,
@@ -98,7 +98,7 @@ unsafe extern "C" fn preadv64(
     // cast away the `const` here.
     match convert_res(rustix::io::preadv(
         BorrowedFd::borrow_raw(fd),
-        slice::from_raw_parts_mut(iov as *mut _, iovcnt as usize),
+        slice::from_raw_parts_mut(iov.cast_mut(), iovcnt as usize),
         offset as u64,
     )) {
         Some(nwritten) => nwritten as isize,

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -40,6 +40,8 @@ mod sync_ptr;
 // the `rustix` APIs directly, which are safer, more ergonomic, and skip this
 // whole layer.
 
+#[cfg(feature = "take-charge")]
+use core::ptr::addr_of;
 use errno::{set_errno, Errno};
 
 mod ctype;
@@ -90,7 +92,7 @@ mod time;
 #[cfg(feature = "take-charge")]
 #[no_mangle]
 static __dso_handle: UnsafeSendSyncVoidStar =
-    UnsafeSendSyncVoidStar(&__dso_handle as *const _ as *const _);
+    UnsafeSendSyncVoidStar(addr_of!(__dso_handle) as *const _);
 
 /// A type for `__dso_handle`.
 ///

--- a/c-scape/src/mem/mem.rs
+++ b/c-scape/src/mem/mem.rs
@@ -13,7 +13,7 @@ unsafe extern "C" fn memchr(s: *const c_void, c: c_int, len: usize) -> *mut c_vo
     // [memchr crate](https://crates.io/crates/memchr)
     for i in 0..len {
         if *s.cast::<u8>().add(i) == c as u8 {
-            return s.cast::<u8>().add(i).cast::<c_void>() as *mut c_void;
+            return s.cast::<u8>().add(i).cast::<c_void>().cast_mut();
         }
     }
     null_mut()
@@ -28,7 +28,7 @@ unsafe extern "C" fn memrchr(s: *const c_void, c: c_int, len: usize) -> *mut c_v
     // requirements that we can't meet here.
     for i in 0..len {
         if *s.cast::<u8>().add(len - i - 1) == c as u8 {
-            return s.cast::<u8>().add(len - i - 1).cast::<c_void>() as *mut c_void;
+            return s.cast::<u8>().add(len - i - 1).cast::<c_void>().cast_mut();
         }
     }
     null_mut()

--- a/c-scape/src/mem/ntbs.rs
+++ b/c-scape/src/mem/ntbs.rs
@@ -68,7 +68,7 @@ unsafe extern "C" fn strcat(d: *mut c_char, s: *const c_char) -> *mut c_char {
 unsafe extern "C" fn strchr(s: *const c_char, c: c_int) -> *mut c_char {
     libc!(libc::strchr(s, c));
 
-    let mut s = s as *mut c_char;
+    let mut s = s.cast_mut();
     loop {
         if *s == c as _ {
             return s;
@@ -230,7 +230,7 @@ unsafe extern "C" fn strnlen(s: *const c_char, mut n: usize) -> usize {
 unsafe extern "C" fn strpbrk(s: *const c_char, m: *const c_char) -> *mut c_char {
     libc!(libc::strpbrk(s, m));
 
-    let s = s.add(strcspn(s, m)) as *mut _;
+    let s = s.add(strcspn(s, m)).cast_mut();
 
     if *s != NUL {
         return s;
@@ -243,7 +243,7 @@ unsafe extern "C" fn strpbrk(s: *const c_char, m: *const c_char) -> *mut c_char 
 unsafe extern "C" fn strrchr(s: *const c_char, c: c_int) -> *mut c_char {
     libc!(libc::strrchr(s, c));
 
-    let mut s = s as *mut c_char;
+    let mut s = s.cast_mut();
     let mut ret = ptr::null_mut::<c_char>();
     loop {
         s = strchr(s, c);
@@ -371,7 +371,7 @@ unsafe extern "C" fn strstr(haystack: *const c_char, needle: *const c_char) -> *
     libc!(libc::strstr(haystack, needle));
 
     if *needle == 0 {
-        return haystack as *mut c_char;
+        return haystack.cast_mut();
     }
 
     let mut haystack = haystack;
@@ -388,7 +388,7 @@ unsafe extern "C" fn strstr(haystack: *const c_char, needle: *const c_char) -> *
             len += 1;
         }
         if *needle.add(len) == 0 {
-            return haystack as *mut c_char;
+            return haystack.cast_mut();
         }
         haystack = haystack.add(1);
     }

--- a/c-scape/src/mm/mod.rs
+++ b/c-scape/src/mm/mod.rs
@@ -166,7 +166,7 @@ unsafe extern "C" fn madvise(addr: *mut c_void, length: size_t, advice: c_int) -
 unsafe extern "C" fn mlock(addr: *mut c_void, len: size_t) -> c_int {
     libc!(libc::mlock(addr, len));
 
-    match convert_res(rustix::mm::mlock(addr as *mut c_void, len)) {
+    match convert_res(rustix::mm::mlock(addr.cast(), len)) {
         Some(()) => 0,
         None => -1,
     }
@@ -177,7 +177,7 @@ unsafe extern "C" fn mlock2(addr: *const c_void, len: size_t, flags: c_uint) -> 
     libc!(libc::mlock2(addr, len, flags));
 
     let flags = rustix::mm::MlockFlags::from_bits_retain(flags);
-    match convert_res(rustix::mm::mlock_with(addr as *mut c_void, len, flags)) {
+    match convert_res(rustix::mm::mlock_with(addr.cast_mut(), len, flags)) {
         Some(()) => 0,
         None => -1,
     }
@@ -187,7 +187,7 @@ unsafe extern "C" fn mlock2(addr: *const c_void, len: size_t, flags: c_uint) -> 
 unsafe extern "C" fn munlock(addr: *const c_void, len: size_t) -> c_int {
     libc!(libc::munlock(addr, len));
 
-    match convert_res(rustix::mm::munlock(addr as *mut c_void, len)) {
+    match convert_res(rustix::mm::munlock(addr.cast_mut(), len)) {
         Some(()) => 0,
         None => -1,
     }

--- a/c-scape/src/net/mod.rs
+++ b/c-scape/src/net/mod.rs
@@ -760,7 +760,7 @@ unsafe extern "C" fn recvmsg(sockfd: c_int, msg: *mut libc::msghdr, flags: c_int
 
     match convert_res(rustix::net::recvmsg(
         fd,
-        slice::from_raw_parts_mut(msg.msg_iov as *mut _, msg.msg_iovlen as usize),
+        slice::from_raw_parts_mut(msg.msg_iov.cast(), msg.msg_iovlen as usize),
         &mut ancillaries,
         flags,
     )) {
@@ -871,7 +871,7 @@ unsafe extern "C" fn sendmsg(sockfd: c_int, msg: *const libc::msghdr, flags: c_i
     match convert_res(rustix::net::sendmsg_any(
         fd,
         addr.as_ref(),
-        slice::from_raw_parts_mut(msg.msg_iov as *mut _, msg.msg_iovlen as usize),
+        slice::from_raw_parts_mut(msg.msg_iov.cast(), msg.msg_iovlen as usize),
         &mut SendAncillaryBuffer::default(),
         flags,
     )) {

--- a/c-scape/src/thread/key.rs
+++ b/c-scape/src/thread/key.rs
@@ -103,7 +103,7 @@ unsafe extern "C" fn pthread_setspecific(key: libc::pthread_key_t, value: *const
 
                         // Call the destructor with the old
                         // data, before we set it to null.
-                        dtor(data as *mut _);
+                        dtor(data);
                     }
                 }
 
@@ -118,7 +118,7 @@ unsafe extern "C" fn pthread_setspecific(key: libc::pthread_key_t, value: *const
 
     VALUES[key as usize].set(ValueWithEpoch {
         epoch: EPOCHS[key as usize].load(Ordering::SeqCst),
-        data: value as *mut _,
+        data: value.cast_mut(),
     });
     0
 }

--- a/c-scape/src/time/mod.rs
+++ b/c-scape/src/time/mod.rs
@@ -30,12 +30,9 @@ unsafe extern "C" fn clock_gettime(id: c_int, tp: *mut libc::timespec) -> c_int 
         _ => panic!("unimplemented clock({})", id),
     };
 
-    let rustix_time = match rustix::time::clock_gettime_dynamic(id) {
-        Ok(rustix_time) => rustix_time,
-        Err(err) => {
-            set_errno(Errno(err.raw_os_error()));
-            return -1;
-        }
+    let rustix_time = match convert_res(rustix::time::clock_gettime_dynamic(id)) {
+        Some(rustix_time) => rustix_time,
+        None => return -1,
     };
 
     match rustix_timespec_to_libc_timespec(rustix_time) {


### PR DESCRIPTION
Use `.cast` and `.cast_mut` to reduce `as` casting, and use `convert_res` to reduce manual errno code.