### PR TITLE
Fix several issues that I found running some POSIX conformance tests.

### DIFF
--- a/c-gull/src/printf.rs
+++ b/c-gull/src/printf.rs
@@ -300,7 +300,7 @@ extern "C" {
     fn __chk_fail();
 }
 
-// <http://refspecs.linux-foundation.org/LSB_4.0.0/LSB-Core-generic/LSB-Core-generic/libc---snprintf-chk-1.html>
+// <https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib---snprintf-chk-1.html>
 #[no_mangle]
 unsafe extern "C" fn __snprintf_chk(
     ptr: *mut c_char,
@@ -322,7 +322,7 @@ unsafe extern "C" fn __snprintf_chk(
     vsnprintf(ptr, len, fmt, va_list)
 }
 
-// <https://refspecs.linuxbase.org/LSB_4.0.0/LSB-Core-generic/LSB-Core-generic/libc---vsnprintf-chk-1.html>
+// <https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib---vsnprintf-chk-1.html>
 #[no_mangle]
 unsafe extern "C" fn __vsnprintf_chk(
     ptr: *mut c_char,
@@ -343,7 +343,7 @@ unsafe extern "C" fn __vsnprintf_chk(
     vsnprintf(ptr, len, fmt, va_list)
 }
 
-// <https://refspecs.linuxbase.org/LSB_4.0.0/LSB-Core-generic/LSB-Core-generic/libc---sprintf-chk-1.html>
+// <https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib---sprintf-chk-1.html>
 #[no_mangle]
 unsafe extern "C" fn __sprintf_chk(
     ptr: *mut c_char,
@@ -370,7 +370,7 @@ unsafe extern "C" fn __sprintf_chk(
     n
 }
 
-// <https://refspecs.linuxbase.org/LSB_4.0.0/LSB-Core-generic/LSB-Core-generic/libc---fprintf-chk-1.html>
+// <https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib---fprintf-chk-1.html>
 #[no_mangle]
 unsafe extern "C" fn __fprintf_chk(
     file: *mut c_void,
@@ -388,7 +388,7 @@ unsafe extern "C" fn __fprintf_chk(
     vfprintf(file, fmt, va_list)
 }
 
-// <https://refspecs.linuxbase.org/LSB_4.0.0/LSB-Core-generic/LSB-Core-generic/libc---vfprintf-chk-1.html>
+// <https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib---vfprintf-chk-1.html>
 #[no_mangle]
 unsafe extern "C" fn __vfprintf_chk(
     file: *mut c_void,
@@ -403,6 +403,19 @@ unsafe extern "C" fn __vfprintf_chk(
     // Our `printf` uses `printf_compat` which doesn't support `%n`.
 
     vfprintf(file, fmt, va_list)
+}
+
+// <https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib---printf-chk-1.html>
+#[no_mangle]
+unsafe extern "C" fn __printf_chk(flag: c_int, fmt: *const c_char, mut args: ...) -> c_int {
+    if flag > 0 {
+        unimplemented!("__USE_FORTIFY_LEVEL > 0");
+    }
+
+    // Our `printf` uses `printf_compat` which doesn't support `%n`.
+
+    let va_list = args.as_va_list();
+    vprintf(fmt, va_list)
 }
 
 #[no_mangle]

--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -19,7 +19,7 @@ cc = { version = "1.0.68", optional = true }
 
 [dependencies]
 libm = "0.2.1"
-rustix = { version = "0.38.14", default-features = false, features = ["event", "fs", "itoa", "mm", "net", "param", "pipe", "process", "rand", "runtime", "stdio", "system", "termios", "thread", "time"] }
+rustix = { version = "0.38.14", default-features = false, features = ["event", "fs", "itoa", "mm", "net", "param", "pipe", "process", "rand", "runtime", "shm", "stdio", "system", "termios", "thread", "time"] }
 rustix-futex-sync = { version = "0.1.1", features = ["atomic_usize"] }
 memoffset = "0.9.0"
 realpath-ext = { version = "0.1.0", default-features = false }

--- a/c-scape/src/fs/memfd.rs
+++ b/c-scape/src/fs/memfd.rs
@@ -1,0 +1,17 @@
+use crate::convert_res;
+use core::ffi::CStr;
+use libc::{c_char, c_int, c_uint};
+use rustix::fd::IntoRawFd;
+use rustix::fs::MemfdFlags;
+
+#[no_mangle]
+unsafe extern "C" fn memfd_create(name: *const c_char, flags: c_uint) -> c_int {
+    libc!(libc::memfd_create(name, flags));
+
+    let name = CStr::from_ptr(name);
+    let flags = MemfdFlags::from_bits_retain(flags);
+    match convert_res(rustix::fs::memfd_create(name, flags)) {
+        Some(fd) => fd.into_raw_fd(),
+        None => -1,
+    }
+}

--- a/c-scape/src/fs/mod.rs
+++ b/c-scape/src/fs/mod.rs
@@ -9,6 +9,7 @@ mod flock;
 mod inotify;
 mod link;
 mod lseek;
+mod memfd;
 mod mkdir;
 mod mknod;
 mod open;

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -48,6 +48,7 @@ mod ctype;
 mod env;
 mod fs;
 mod io;
+mod shm;
 
 #[cfg(feature = "take-charge")]
 mod malloc;

--- a/c-scape/src/mem/chk.rs
+++ b/c-scape/src/mem/chk.rs
@@ -2,7 +2,7 @@
 
 use libc::{c_char, c_int, c_void, size_t};
 
-// <https://refspecs.linuxbase.org/LSB_4.0.0/LSB-Core-generic/LSB-Core-generic/libc---chk-fail-1.html>
+// <https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib---chk-fail-1.html>
 #[no_mangle]
 unsafe extern "C" fn __chk_fail() -> ! {
     rustix::io::write(
@@ -13,7 +13,7 @@ unsafe extern "C" fn __chk_fail() -> ! {
     libc::abort();
 }
 
-// <http://refspecs.linux-foundation.org/LSB_4.0.0/LSB-Core-generic/LSB-Core-generic/libc---strcpy-chk-1.html>
+// <https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib---strcpy-chk-1.html>
 #[no_mangle]
 unsafe extern "C" fn __strcpy_chk(
     dest: *mut c_char,
@@ -29,7 +29,7 @@ unsafe extern "C" fn __strcpy_chk(
     libc::strcpy(dest, src)
 }
 
-// <http://refspecs.linux-foundation.org/LSB_4.0.0/LSB-Core-generic/LSB-Core-generic/libc---memcpy-chk-1.html>
+// <https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib---memcpy-chk-1.html>
 #[no_mangle]
 unsafe extern "C" fn __memcpy_chk(
     dest: *mut c_void,
@@ -44,7 +44,7 @@ unsafe extern "C" fn __memcpy_chk(
     libc::memcpy(dest, src, len)
 }
 
-// <http://refspecs.linux-foundation.org/LSB_4.0.0/LSB-Core-generic/LSB-Core-generic/libc---memset-chk-1.html>
+// <https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib---memset-chk-1.html>
 #[no_mangle]
 unsafe extern "C" fn __memset_chk(
     dest: *mut c_void,
@@ -59,7 +59,7 @@ unsafe extern "C" fn __memset_chk(
     libc::memset(dest, c, len)
 }
 
-// <https://refspecs.linuxbase.org/LSB_4.0.0/LSB-Core-generic/LSB-Core-generic/libc---strcat-chk-1.html>
+// <https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib---strcat-chk-1.html>
 #[no_mangle]
 unsafe extern "C" fn __strcat_chk(
     dest: *mut c_char,
@@ -80,7 +80,7 @@ unsafe extern "C" fn __strcat_chk(
     __chk_fail()
 }
 
-// <https://refspecs.linuxbase.org/LSB_4.0.0/LSB-Core-generic/LSB-Core-generic/libc---strncpy-chk-1.html>
+// <https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib---strncpy-chk-1.html>
 #[no_mangle]
 unsafe extern "C" fn __strncpy_chk(
     dest: *mut c_char,
@@ -95,7 +95,7 @@ unsafe extern "C" fn __strncpy_chk(
     libc::strncpy(dest, src, len)
 }
 
-// <https://refspecs.linuxbase.org/LSB_4.0.0/LSB-Core-generic/LSB-Core-generic/libc---fgets-chk-1.html>
+// <https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib---fgets-chk-1.html>
 #[no_mangle]
 unsafe extern "C" fn __fgets_chk(
     s: *mut c_char,

--- a/c-scape/src/process/wait.rs
+++ b/c-scape/src/process/wait.rs
@@ -1,5 +1,5 @@
 //use errno::{set_errno, Errno};
-use libc::c_int;
+use libc::{c_int, pid_t};
 use rustix::process::{Pid, WaitOptions};
 
 use crate::convert_res;
@@ -65,4 +65,10 @@ unsafe extern "C" fn waitpid(pid: c_int, status: *mut c_int, options: c_int) -> 
         status.write(ret_status);
     }
     ret_pid
+}
+
+#[no_mangle]
+unsafe extern "C" fn wait(status: *mut c_int) -> pid_t {
+    libc!(libc::wait(status));
+    waitpid(-1, status, 0)
 }

--- a/c-scape/src/shm/mod.rs
+++ b/c-scape/src/shm/mod.rs
@@ -1,0 +1,30 @@
+use crate::convert_res;
+use core::ffi::CStr;
+use libc::{c_char, c_int, mode_t};
+use rustix::fd::IntoRawFd;
+use rustix::fs::Mode;
+use rustix::shm::ShmOFlags;
+
+#[no_mangle]
+unsafe extern "C" fn shm_open(name: *const c_char, oflags: c_int, mode: mode_t) -> c_int {
+    libc!(libc::shm_open(name, oflags, mode));
+
+    let name = CStr::from_ptr(name);
+    let mode = Mode::from_bits((mode & !libc::S_IFMT) as _).unwrap();
+    let oflags = ShmOFlags::from_bits(oflags as _).unwrap();
+    match convert_res(rustix::shm::shm_open(name, oflags, mode)) {
+        Some(fd) => fd.into_raw_fd(),
+        None => -1,
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn shm_unlink(name: *const c_char) -> c_int {
+    libc!(libc::shm_unlink(name));
+
+    let name = CStr::from_ptr(name);
+    match convert_res(rustix::shm::shm_unlink(name)) {
+        Some(()) => 0,
+        None => -1,
+    }
+}

--- a/c-scape/src/signal/mod.rs
+++ b/c-scape/src/signal/mod.rs
@@ -30,6 +30,24 @@ unsafe extern "C" fn signal(signal: c_int, handler: sighandler_t) -> sighandler_
 }
 
 #[no_mangle]
+unsafe extern "C" fn sysv_signal(signal: c_int, handler: sighandler_t) -> sighandler_t {
+    //libc!(libc::sysv_signal(signal, handler));
+    libc::signal(signal, handler)
+}
+
+#[no_mangle]
+unsafe extern "C" fn __sysv_signal(signal: c_int, handler: sighandler_t) -> sighandler_t {
+    //libc!(libc::__sysv_signal(signal, handler));
+    sysv_signal(signal, handler)
+}
+
+#[no_mangle]
+unsafe extern "C" fn bsd_signal(signal: c_int, handler: sighandler_t) -> sighandler_t {
+    //libc!(libc::bsd_signal(signal, handler));
+    libc::signal(signal, handler)
+}
+
+#[no_mangle]
 unsafe extern "C" fn sigaction(signal: c_int, new: *const sigaction, old: *mut sigaction) -> c_int {
     libc!(libc::sigaction(signal, new, old));
 


### PR DESCRIPTION
Fix several functions to better diagnose invalid argument values.

And implement mlockall, munlockall, __printf_chk, __sysconf, fpathconf, pathconf, shm_open, shm_unlink, sleep, usleep, memfd_create, and _SC_DELAYTIMER_MAX.