### PR TITLE
Implement more features.

### DIFF
--- a/c-scape/src/process_.rs
+++ b/c-scape/src/process_.rs
@@ -35,7 +35,7 @@ unsafe fn _sysconf(name: c_int) -> c_long {
         libc::_SC_PAGESIZE => rustix::param::page_size() as _,
         libc::_SC_CLK_TCK => rustix::param::clock_ticks_per_second() as _,
         #[cfg(not(target_os = "wasi"))]
-        libc::_SC_GETPW_R_SIZE_MAX => -1,
+        libc::_SC_GETPW_R_SIZE_MAX | libc::_SC_GETGR_R_SIZE_MAX => -1,
         #[cfg(any(target_os = "android", target_os = "linux", target_os = "wasi"))]
         libc::_SC_SYMLOOP_MAX => 40,
         libc::_SC_HOST_NAME_MAX => 255,


### PR DESCRIPTION
Implement `SO_PEERCRED`, a few more `sysconf` codes, and `accept` taking a null destination address or getting an `AF_UNSPEC` address.

And add a special case for Unix-domain addresses where the caller has forgotten to add 1 for the NUL terminator to fix it up, so that rustix doesn't have to be aware of this.