### PR TITLE
Update to rustix 0.38.22.

### DIFF
--- a/c-gull/Cargo.toml
+++ b/c-gull/Cargo.toml
@@ -19,7 +19,7 @@ c-scape = { path = "../c-scape", version = "0.15.16", default-features = false }
 errno = { version = "0.3.3", default-features = false, optional = true }
 tz-rs = { version = "0.6.11", default-features = false, optional = true }
 printf-compat = { version = "0.1.1", optional = true }
-rustix = { version = "0.38.10", default-features = false, optional = true, features = ["fs", "itoa", "net", "param", "process", "procfs", "rand", "termios", "thread", "time"] }
+rustix = { version = "0.38.22", default-features = false, optional = true, features = ["fs", "itoa", "net", "param", "process", "procfs", "rand", "termios", "thread", "time"] }
 
 [features]
 default = ["thread", "std", "coexist-with-libc"]

--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -19,7 +19,7 @@ cc = { version = "1.0.68", optional = true }
 
 [dependencies]
 libm = "0.2.1"
-rustix = { version = "0.38.14", default-features = false, features = ["event", "fs", "itoa", "mm", "net", "param", "pipe", "process", "rand", "runtime", "shm", "stdio", "system", "termios", "thread", "time"] }
+rustix = { version = "0.38.22", default-features = false, features = ["event", "fs", "itoa", "mm", "net", "param", "pipe", "process", "rand", "runtime", "shm", "stdio", "system", "termios", "thread", "time"] }
 rustix-futex-sync = { version = "0.1.1", features = ["atomic_usize"] }
 memoffset = "0.9.0"
 realpath-ext = { version = "0.1.0", default-features = false }

--- a/c-scape/src/process_.rs
+++ b/c-scape/src/process_.rs
@@ -300,6 +300,14 @@ unsafe extern "C" fn __sched_cpufree(set: *mut libc::cpu_set_t) {
     libc::free(set.cast());
 }
 
+#[cfg(not(target_os = "wasi"))]
+#[no_mangle]
+unsafe extern "C" fn sched_getcpu() -> c_int {
+    libc!(libc::sched_getcpu());
+
+    rustix::process::sched_getcpu() as _
+}
+
 // In Linux, `prctl`'s arguments are described as `unsigned long`, however we
 // use pointer types in order to preserve provenance.
 #[cfg(any(target_os = "android", target_os = "linux"))]

--- a/c-scape/src/todo.rs
+++ b/c-scape/src/todo.rs
@@ -234,10 +234,6 @@ unsafe extern "C" fn renameat2() {
     todo!("renameat2")
 }
 #[no_mangle]
-unsafe extern "C" fn sched_getcpu() {
-    todo!("sched_getcpu")
-}
-#[no_mangle]
 unsafe extern "C" fn sendmmsg() {
     todo!("sendmmsg")
 }


### PR DESCRIPTION
Update to rustix 0.38.22, with the new `fork` API, `readlinikat_raw`, and `sched_getcpu`.