### PR TITLE
Make use of `compiler_builtins` optional.

### DIFF
--- a/c-gull/Cargo.toml
+++ b/c-gull/Cargo.toml
@@ -22,7 +22,7 @@ printf-compat = { version = "0.1.1", optional = true }
 rustix = { version = "0.38.23", default-features = false, optional = true, features = ["fs", "itoa", "net", "param", "process", "procfs", "rand", "termios", "thread", "time"] }
 
 [features]
-default = ["thread", "std", "coexist-with-libc", "threadsafe-setenv"]
+default = ["thread", "std", "coexist-with-libc", "threadsafe-setenv", "use-compiler-builtins"]
 thread = ["c-scape/thread"]
 std = ["c-scape/std", "rustix/std", "printf-compat/std", "tz-rs/std", "errno/std"]
 
@@ -36,6 +36,9 @@ call-main = ["c-scape/call-main"]
 # `compiler_builtins::mem`) or should it rely on `compiler_builtins`
 # being linked in and providing those definitions?
 define-mem-functions = ["c-scape/define-mem-functions"]
+
+# Should c-scape's `memcpy` etc. use compiler-builtins?
+use-compiler-builtins = ["c-scape/use-compiler-builtins"]
 
 # Enable logging of program and thread startup and shutdown.
 log = ["c-scape/log"]

--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -60,7 +60,7 @@ libc = "0.2.138"
 static_assertions = "1.1.0"
 
 [features]
-default = ["thread", "std", "coexist-with-libc", "threadsafe-setenv"]
+default = ["thread", "std", "coexist-with-libc", "threadsafe-setenv", "use-compiler-builtins"]
 thread = ["origin/set_thread_id"]
 std = ["rustix/std"]
 
@@ -74,6 +74,9 @@ call-main = []
 # `compiler_builtins::mem`) or should it rely on `compiler_builtins`
 # being linked in and providing those definitions?
 define-mem-functions = []
+
+# Should c-scape's `memcpy` etc. use compiler-builtins?
+use-compiler-builtins = []
 
 # Enable logging of program and thread startup and shutdown.
 log = ["origin/log"]

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -2,7 +2,7 @@
 #![no_std]
 #![feature(thread_local)] // for `__errno_location`
 #![feature(c_variadic)] // for `ioctl` etc.
-#![feature(rustc_private)] // for compiler-builtins
+#![cfg_attr(feature = "use-compiler-builtins", feature(rustc_private))]
 #![feature(strict_provenance)]
 #![feature(inline_const)]
 #![feature(sync_unsafe_cell)]
@@ -15,6 +15,7 @@ compile_error!("Enable only one of \"coexist-with-libc\" and \"take-charge\".");
 compile_error!("Enable one \"coexist-with-libc\" and \"take-charge\".");
 
 extern crate alloc;
+#[cfg(feature = "use-compiler-builtins")]
 extern crate compiler_builtins;
 
 // Re-export the libc crate's API. This allows users to depend on the c-scape

--- a/c-scape/src/mem/ntbs.rs
+++ b/c-scape/src/mem/ntbs.rs
@@ -169,7 +169,22 @@ unsafe extern "C" fn strdup(s: *const c_char) -> *mut c_char {
 unsafe extern "C" fn strlen(s: *const c_char) -> usize {
     libc!(libc::strlen(s));
 
-    compiler_builtins::mem::strlen(s)
+    #[cfg(feature = "use-compiler-builtins")]
+    {
+        compiler_builtins::mem::strlen(s)
+    }
+
+    #[cfg(not(feature = "use-compiler-builtins"))]
+    {
+        let mut s = s;
+        let mut n = 0;
+        while *s != 0 {
+            n += 1;
+            s = s.add(1);
+            core::arch::asm!("");
+        }
+        n
+    }
 }
 
 #[no_mangle]


### PR DESCRIPTION
`compiler_builtins` is a very special crate, that needs `feature(rustc_private)`, that's installed along with rustc, and that appears to have some magic linking behavior, so in some situations it's desirable to avoid using it. Add an option to disable it, falling back to simple implementations.