### PR TITLE
Add an "eyra" feature to c-scape, to better support no-std Eyra.

### DIFF
--- a/c-gull/Cargo.toml
+++ b/c-gull/Cargo.toml
@@ -58,14 +58,7 @@ experimental-relocate = ["c-scape/experimental-relocate"]
 
 # A feature that pulls in all the individual features needed to use
 # c-gull to write Rust programs completely implemented in Rust.
-eyra = [
-    "take-charge",
-    "std",
-    "thread",
-    "call-main",
-    "malloc-via-crates",
-    "define-mem-functions"
-]
+eyra = ["c-scape/eyra"]
 
 # One of the following two features must be enabled:
 

--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -94,6 +94,17 @@ max_level_off = ["origin/max_level_off"]
 # needed to support statically-linked PIE executables.
 experimental-relocate = ["origin/experimental-relocate"]
 
+# A feature that pulls in all the individual features needed to use
+# c-scape to write Rust programs completely implemented in Rust.
+eyra = [
+    "take-charge",
+    "std",
+    "thread",
+    "call-main",
+    "malloc-via-crates",
+    "define-mem-functions"
+]
+
 # One of the following two features must be enabled:
 
 # Enable this to tell c-scape to take control of the process.


### PR DESCRIPTION
Instead of having c-gull define the "eyra" feature, define it in c-scape, and have c-gull depend on it. c-scape doesn't depend on std, so this will allow the eyra crate to offer a no-std mode which only depends on c-scape.