### PR TITLE
Change the `checked_cast` macro to not execute the loads.

### DIFF
--- a/c-gull/src/use_libc.rs
+++ b/c-gull/src/use_libc.rs
@@ -11,7 +11,7 @@ macro_rules! checked_cast {
         let src_ptr = $ptr;
         let target_ptr = src_ptr.cast();
 
-        if !src_ptr.is_null() {
+        if false {
             let target = crate::use_libc::Pad::new(core::ptr::read(target_ptr));
 
             // Uses the fact that the compiler checks for size equality,

--- a/c-scape/src/use_libc.rs
+++ b/c-scape/src/use_libc.rs
@@ -11,7 +11,7 @@ macro_rules! checked_cast {
         let src_ptr = $ptr;
         let target_ptr = src_ptr.cast();
 
-        if !src_ptr.is_null() {
+        if false {
             let target = crate::use_libc::Pad::new(core::ptr::read(target_ptr));
 
             // Uses the fact that the compiler checks for size equality,


### PR DESCRIPTION
This macro works by using `transmute` to test for sizes at compile time, so it doesn't need to run the code.