### PR TITLE
Implement several more functions, and make `opendir` avoid reopening the directory

### DIFF
--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -19,7 +19,7 @@ cc = { version = "1.0.68", optional = true }
 
 [dependencies]
 libm = "0.2.1"
-rustix = { version = "0.38.23", default-features = false, features = ["event", "fs", "itoa", "mm", "net", "param", "pipe", "process", "rand", "runtime", "shm", "stdio", "system", "termios", "thread", "time"] }
+rustix = { version = "0.38.26", default-features = false, features = ["event", "fs", "itoa", "mm", "net", "param", "pipe", "process", "rand", "runtime", "shm", "stdio", "system", "termios", "thread", "time"] }
 rustix-futex-sync = { version = "0.1.1", features = ["atomic_usize"] }
 memoffset = "0.9.0"
 realpath-ext = { version = "0.1.0", default-features = false }

--- a/c-scape/src/fs/dir/dirfd.rs
+++ b/c-scape/src/fs/dir/dirfd.rs
@@ -1,5 +1,3 @@
-use rustix::fd::{AsFd, AsRawFd};
-
 use libc::{c_int, c_void};
 
 use super::CScapeDir;
@@ -9,5 +7,5 @@ unsafe extern "C" fn dirfd(dir: *mut c_void) -> c_int {
     libc!(libc::dirfd(dir.cast()));
 
     let dir = dir.cast::<CScapeDir>();
-    (*dir).fd.as_fd().as_raw_fd()
+    (*dir).fd
 }

--- a/c-scape/src/fs/dir/mod.rs
+++ b/c-scape/src/fs/dir/mod.rs
@@ -3,7 +3,7 @@ mod opendir;
 #[cfg(not(target_os = "wasi"))]
 mod readdir;
 
-use rustix::fd::OwnedFd;
+use rustix::fd::RawFd;
 
 union LibcDirStorage {
     dirent: libc::dirent,
@@ -13,5 +13,5 @@ union LibcDirStorage {
 struct CScapeDir {
     dir: rustix::fs::Dir,
     storage: LibcDirStorage,
-    fd: OwnedFd,
+    fd: RawFd,
 }

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -89,6 +89,7 @@ mod int;
 mod locale;
 mod mkostemps;
 mod nss;
+mod pause;
 mod posix_spawn;
 mod process_;
 mod pty;

--- a/c-scape/src/pause.rs
+++ b/c-scape/src/pause.rs
@@ -1,0 +1,14 @@
+use errno::{set_errno, Errno};
+use libc::c_int;
+
+#[no_mangle]
+unsafe extern "C" fn pause() -> c_int {
+    libc!(libc::pause());
+
+    rustix::event::pause();
+
+    // `pause` sleeps until it is interrupted by a signal, so it always fails
+    // with `EINTR`.
+    set_errno(Errno(libc::EINTR));
+    -1
+}

--- a/c-scape/src/process/kill.rs
+++ b/c-scape/src/process/kill.rs
@@ -56,19 +56,3 @@ unsafe extern "C" fn killpg(pgid: pid_t, sig: c_int) -> c_int {
 
     kill(-pgid, sig)
 }
-
-/// This function conforms to the [LSB `__libc_current_sigrtmax`] ABI.
-///
-/// [LSB `__libc_current_sigrtmax`]: https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib---libc-current-sigrtmax-1.html
-#[no_mangle]
-unsafe extern "C" fn __libc_current_sigrtmax() -> c_int {
-    libc!(libc::__libc_current_sigrtmax());
-
-    // TODO: Upstream `NSIG` into the libc crate.
-    #[cfg(not(any(target_arch = "mips", target_arch = "mips64")))]
-    let nsig = 65;
-    #[cfg(any(target_arch = "mips", target_arch = "mips64"))]
-    let nsig = 128;
-
-    nsig - 1
-}

--- a/c-scape/src/signal/mod.rs
+++ b/c-scape/src/signal/mod.rs
@@ -171,6 +171,18 @@ unsafe extern "C" fn sigpending(set: *mut sigset_t) -> c_int {
 }
 
 #[no_mangle]
+unsafe extern "C" fn sigsuspend(set: *const sigset_t) -> c_int {
+    libc!(libc::sigsuspend(set));
+
+    let set: *const Sigset = set.cast();
+
+    match convert_res(rustix::runtime::sigsuspend(&*set)) {
+        Some(()) => 0,
+        None => -1,
+    }
+}
+
+#[no_mangle]
 unsafe extern "C" fn sigaltstack(new: *const stack_t, old: *mut stack_t) -> c_int {
     libc!(libc::sigaltstack(new, old));
 

--- a/c-scape/src/signal/mod.rs
+++ b/c-scape/src/signal/mod.rs
@@ -160,6 +160,17 @@ unsafe extern "C" fn sigprocmask(how: c_int, set: *const sigset_t, oldset: *mut 
 }
 
 #[no_mangle]
+unsafe extern "C" fn sigpending(set: *mut sigset_t) -> c_int {
+    libc!(libc::sigpending(set));
+
+    let set: *mut Sigset = set.cast();
+
+    let pending = rustix::runtime::sigpending();
+    set.write(pending);
+    0
+}
+
+#[no_mangle]
 unsafe extern "C" fn sigaltstack(new: *const stack_t, old: *mut stack_t) -> c_int {
     libc!(libc::sigaltstack(new, old));
 

--- a/c-scape/src/todo.rs
+++ b/c-scape/src/todo.rs
@@ -1295,10 +1295,6 @@ unsafe extern "C" fn sched_setscheduler() {
     todo!("sched_setscheduler")
 }
 #[no_mangle]
-unsafe extern "C" fn sigpending() {
-    todo!("sigpending")
-}
-#[no_mangle]
 unsafe extern "C" fn sigqueue() {
     todo!("sigqueue")
 }

--- a/c-scape/src/todo.rs
+++ b/c-scape/src/todo.rs
@@ -166,10 +166,6 @@ unsafe extern "C" fn if_nametoindex() {
     todo!("if_nametoindex")
 }
 #[no_mangle]
-unsafe extern "C" fn pause() {
-    todo!("pause")
-}
-#[no_mangle]
 unsafe extern "C" fn ppoll() {
     todo!("ppoll")
 }
@@ -837,10 +833,6 @@ unsafe extern "C" fn iswxdigit() {
 #[no_mangle]
 unsafe extern "C" fn lfind() {
     todo!("lfind")
-}
-#[no_mangle]
-unsafe extern "C" fn __libc_current_sigrtmin() {
-    todo!("__libc_current_sigrtmin")
 }
 #[no_mangle]
 unsafe extern "C" fn lrint() {

--- a/c-scape/src/todo.rs
+++ b/c-scape/src/todo.rs
@@ -621,10 +621,6 @@ unsafe extern "C" fn regfree() {
 unsafe extern "C" fn setgrent() {
     todo!("setgrent")
 }
-#[no_mangle]
-unsafe extern "C" fn sigsuspend() {
-    todo!("sigsuspend")
-}
 #[deprecated]
 #[no_mangle]
 unsafe extern "C" fn sighold() {


### PR DESCRIPTION
 - Implement `pause`, `__libc_current_sigrtmin`, `__libc_current_sigrtmax`
 - Implement `sigpending`.
 - Implement `sigsuspend`.
 - Make `opendir` avoid opening a new file descriptor.

