### PR TITLE
Implement more "chk" functions and more integer operations.

### DIFF
--- a/c-gull/src/lib.rs
+++ b/c-gull/src/lib.rs
@@ -37,6 +37,7 @@ mod time;
 mod utmp;
 
 #[cfg(feature = "std")]
+#[cold]
 #[no_mangle]
 unsafe extern "C" fn __assert_fail(
     expr: *const c_char,

--- a/c-scape/src/int.rs
+++ b/c-scape/src/int.rs
@@ -1,4 +1,5 @@
-/// Integer math.
+//! Integer math.
+
 use libc::{c_int, c_long, c_longlong, intmax_t};
 
 #[no_mangle]
@@ -13,24 +14,24 @@ unsafe extern "C" fn ffs(i: c_int) -> c_int {
 }
 
 #[no_mangle]
-unsafe extern "C" fn ffsl(i: c_long) -> c_long {
+unsafe extern "C" fn ffsl(i: c_long) -> c_int {
     //libc!(libc::ffsl(i));
 
     if i == 0 {
         0
     } else {
-        i.trailing_zeros() as c_long + 1
+        i.trailing_zeros() as c_int + 1
     }
 }
 
 #[no_mangle]
-unsafe extern "C" fn ffsll(i: c_longlong) -> c_longlong {
+unsafe extern "C" fn ffsll(i: c_longlong) -> c_int {
     //libc!(libc::ffsll(i));
 
     if i == 0 {
         0
     } else {
-        i.trailing_zeros() as c_longlong + 1
+        i.trailing_zeros() as c_int + 1
     }
 }
 
@@ -109,4 +110,32 @@ unsafe extern "C" fn lldiv(numerator: c_longlong, denominator: c_longlong) -> ll
         quot: numerator / denominator,
         rem: numerator % denominator,
     }
+}
+
+#[no_mangle]
+unsafe extern "C" fn __ffsdi2(i: c_long) -> c_int {
+    //libc!(libc::__ffsdi2(i));
+
+    ffsl(i)
+}
+
+#[no_mangle]
+unsafe extern "C" fn __clzdi2(i: c_long) -> c_int {
+    //libc!(libc::__clzdi2(i));
+
+    i.leading_zeros() as c_int
+}
+
+#[no_mangle]
+unsafe extern "C" fn __ctzdi2(i: c_long) -> c_int {
+    //libc!(libc::__ctzdi2(i));
+
+    i.trailing_zeros() as c_int
+}
+
+#[no_mangle]
+unsafe extern "C" fn __popcountdi2(i: c_long) -> c_int {
+    //libc!(libc::__popcountdi2(i));
+
+    i.count_ones() as c_int
 }

--- a/c-scape/src/mem/chk.rs
+++ b/c-scape/src/mem/chk.rs
@@ -3,6 +3,7 @@
 use libc::{c_char, c_int, c_void, size_t};
 
 // <https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib---chk-fail-1.html>
+#[cold]
 #[no_mangle]
 unsafe extern "C" fn __chk_fail() -> ! {
     rustix::io::write(

--- a/c-scape/src/stdio.rs
+++ b/c-scape/src/stdio.rs
@@ -823,7 +823,8 @@ unsafe extern "C" fn vfprintf(
 // C functions not in the libc crate, due to `VaList` being unstable.
 
 extern "C" {
-    fn __chk_fail();
+    #[cold]
+    fn __chk_fail() -> !;
 }
 
 // <https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib---snprintf-chk-1.html>

--- a/c-scape/src/syscall.rs
+++ b/c-scape/src/syscall.rs
@@ -141,7 +141,10 @@ unsafe extern "C" fn syscall(number: c_long, mut args: ...) -> *mut c_void {
             libc::sync();
             invalid_mut(0)
         }
-        _ => unimplemented!("syscall({:?})", number),
+        _ => unimplemented!(
+            "syscall({:?}); maybe try enabling the \"extra-syscalls\" feature",
+            number
+        ),
     }
 }
 


### PR DESCRIPTION
Implement `__stack_chk_fail` and several more `*_chk` functions, as well as `__popcountdi2` and several integer functions.