### PR TITLE
Use the new `_uninit` APIs in rustix 0.38.27.

### DIFF
--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -19,7 +19,7 @@ cc = { version = "1.0.68", optional = true }
 
 [dependencies]
 libm = "0.2.1"
-rustix = { version = "0.38.26", default-features = false, features = ["event", "fs", "itoa", "mm", "net", "param", "pipe", "process", "rand", "runtime", "shm", "stdio", "system", "termios", "thread", "time"] }
+rustix = { version = "0.38.27", default-features = false, features = ["event", "fs", "itoa", "mm", "net", "param", "pipe", "process", "rand", "runtime", "shm", "stdio", "system", "termios", "thread", "time"] }
 rustix-futex-sync = { version = "0.2.1", features = ["atomic_usize"] }
 memoffset = "0.9.0"
 realpath-ext = { version = "0.1.0", default-features = false }

--- a/c-scape/src/rand_.rs
+++ b/c-scape/src/rand_.rs
@@ -1,59 +1,49 @@
-use crate::{convert_res, READ_BUFFER};
-use core::cmp::min;
+use crate::convert_res;
+use core::mem::MaybeUninit;
+use core::slice;
 use errno::{set_errno, Errno};
 use libc::c_void;
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[no_mangle]
-unsafe extern "C" fn getrandom(buf: *mut c_void, buflen: usize, flags: u32) -> isize {
-    libc!(libc::getrandom(buf, buflen, flags));
+unsafe extern "C" fn getrandom(ptr: *mut c_void, len: usize, flags: u32) -> isize {
+    libc!(libc::getrandom(ptr, len, flags));
 
-    if buflen == 0 {
+    if len == 0 {
         return 0;
     }
 
     let flags = rustix::rand::GetRandomFlags::from_bits_retain(flags);
+    let buf = slice::from_raw_parts_mut(ptr.cast::<MaybeUninit<u8>>(), len);
 
-    // `slice::from_raw_parts_mut` assumes that the memory is initialized,
-    // which our C API here doesn't guarantee. Since rustix currently requires
-    // a slice, use a temporary copy.
-    match convert_res(rustix::rand::getrandom(
-        &mut READ_BUFFER[..min(buflen, READ_BUFFER.len())],
-        flags,
-    )) {
-        Some(num) => {
-            core::ptr::copy_nonoverlapping(READ_BUFFER.as_ptr(), buf.cast::<u8>(), num);
-            num as isize
-        }
+    match convert_res(rustix::rand::getrandom_uninit(buf, flags)) {
+        Some((init, _uninit)) => init.len() as isize,
         None => -1,
     }
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[no_mangle]
-unsafe extern "C" fn getentropy(buf: *mut c_void, buflen: usize) -> i32 {
-    libc!(libc::getentropy(buf, buflen));
+unsafe extern "C" fn getentropy(ptr: *mut c_void, len: usize) -> i32 {
+    libc!(libc::getentropy(ptr, len));
 
-    if buflen == 0 {
+    if len == 0 {
         return 0;
     }
 
-    if buflen >= 256 {
+    if len >= 256 {
         set_errno(Errno(libc::EIO));
         return -1;
     }
-    assert!(buflen < READ_BUFFER.len());
 
     let flags = rustix::rand::GetRandomFlags::empty();
+    let buf = slice::from_raw_parts_mut(ptr.cast::<MaybeUninit<u8>>(), len);
 
     let mut filled = 0usize;
 
-    // `slice::from_raw_parts_mut` assumes that the memory is initialized,
-    // which our C API here doesn't guarantee. Since rustix currently requires
-    // a slice, use a temporary copy.
-    while filled < buflen {
-        match rustix::rand::getrandom(&mut READ_BUFFER[filled..buflen], flags) {
-            Ok(num) => filled += num,
+    while !buf.is_empty() {
+        match rustix::rand::getrandom_uninit(&mut buf[filled..], flags) {
+            Ok((init, _uninit)) => filled += init.len(),
             Err(rustix::io::Errno::INTR) => {}
             Err(err) => {
                 set_errno(Errno(err.raw_os_error()));
@@ -61,8 +51,6 @@ unsafe extern "C" fn getentropy(buf: *mut c_void, buflen: usize) -> i32 {
             }
         }
     }
-
-    core::ptr::copy_nonoverlapping(READ_BUFFER.as_ptr(), buf.cast::<u8>(), buflen);
 
     0
 }


### PR DESCRIPTION
This eliminates the use of `READ_BUFFER` with its length limitation and extra copying.