### PR TITLE
Update CI to the latest Rust nightly.

### DIFF
--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(c_variadic)] // for `ioctl` etc.
 #![cfg_attr(feature = "use-compiler-builtins", feature(rustc_private))]
 #![feature(strict_provenance)]
+#![feature(exposed_provenance)]
 #![feature(inline_const)]
 #![feature(sync_unsafe_cell)]
 #![feature(linkage)]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-11-19"
+channel = "nightly-2023-12-09"
 components = ["rustc", "cargo", "rust-std", "rust-src", "rustfmt"]


### PR DESCRIPTION
This requires adding `#![feature(exposed_provenance)]`.