### PR TITLE
Make `cargo test --workspace` useful.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,6 +113,6 @@ jobs:
 
     - name: cargo test
       run: |
-        cargo test
+        cargo test --workspace
       env:
         RUST_BACKTRACE: 1

--- a/c-gull/src/system.rs
+++ b/c-gull/src/system.rs
@@ -29,3 +29,15 @@ fn _system(command: &OsStr) -> c_int {
         }
     }
 }
+
+#[test]
+fn test_system() {
+    unsafe {
+        use rustix::cstr;
+        assert_eq!(system(core::ptr::null()), 1);
+
+        let t = system(cstr!("/bin/sh -c exit\\ 42").as_ptr());
+        assert!(libc::WIFEXITED(t));
+        assert_eq!(libc::WEXITSTATUS(t), 42);
+    }
+}

--- a/c-gull/src/use_libc.rs
+++ b/c-gull/src/use_libc.rs
@@ -32,7 +32,7 @@ macro_rules! checked_cast {
 ///
 /// # Example
 ///
-/// ```no_run
+/// ```no_compile
 /// #[no_mangle]
 /// unsafe extern "C" fn strlen(s: *const c_char) -> usize {
 ///     libc!(libc::strlen(s));

--- a/c-scape/src/fs/makedev.rs
+++ b/c-scape/src/fs/makedev.rs
@@ -1,3 +1,8 @@
+//! `major`, `minor`, and `makedev`.
+//!
+//! These are macros in libc, so the Rust libc crate defines them itself as
+//! functions, so we can just call those functions here.
+
 #[no_mangle]
 unsafe extern "C" fn gnu_dev_major(dev: libc::dev_t) -> u32 {
     libc::major(dev)

--- a/c-scape/src/path/mod.rs
+++ b/c-scape/src/path/mod.rs
@@ -111,3 +111,44 @@ unsafe extern "C" fn dirname(path: *mut c_char) -> *mut c_char {
     *path.add(i) = 0;
     path
 }
+
+#[test]
+fn test_dirname_basename() {
+    use core::ffi::CStr;
+
+    fn test(input: &CStr, expected_dir: &CStr, expected_gnu: &CStr, expected_posix: &CStr) {
+        unsafe {
+            let mut s = input.to_bytes_with_nul().to_vec();
+            let i = s.as_mut_ptr().cast();
+            let o = libc::dirname(i);
+            assert_eq!(CStr::from_ptr(o), expected_dir);
+
+            let mut s = input.to_bytes_with_nul().to_vec();
+            let i = s.as_mut_ptr().cast();
+            let o = libc::gnu_basename(i);
+            assert_eq!(CStr::from_ptr(o), expected_gnu);
+
+            let mut s = input.to_bytes_with_nul().to_vec();
+            let i = s.as_mut_ptr().cast();
+            let o = libc::posix_basename(i);
+            assert_eq!(CStr::from_ptr(o), expected_posix);
+        }
+    }
+
+    test(cstr!("/usr/lib"), cstr!("/usr"), cstr!("lib"), cstr!("lib"));
+    test(
+        cstr!("/usr//lib"),
+        cstr!("/usr"),
+        cstr!("lib"),
+        cstr!("lib"),
+    );
+    test(cstr!("/usr/lib/"), cstr!("/usr"), cstr!(""), cstr!("lib"));
+    test(cstr!("/usr/lib//"), cstr!("/usr"), cstr!(""), cstr!("lib"));
+    test(cstr!("/"), cstr!("/"), cstr!(""), cstr!("/"));
+    test(cstr!("//"), cstr!("//"), cstr!(""), cstr!("/"));
+    test(cstr!("///"), cstr!("/"), cstr!(""), cstr!("/"));
+    test(cstr!(""), cstr!("."), cstr!(""), cstr!("."));
+    test(cstr!("usr"), cstr!("."), cstr!("usr"), cstr!("usr"));
+    test(cstr!("usr/"), cstr!("."), cstr!(""), cstr!("usr"));
+    test(cstr!("usr//"), cstr!("."), cstr!(""), cstr!("usr"));
+}

--- a/c-scape/src/use_libc.rs
+++ b/c-scape/src/use_libc.rs
@@ -32,7 +32,7 @@ macro_rules! checked_cast {
 ///
 /// # Example
 ///
-/// ```no_run
+/// ```no_compile
 /// #[no_mangle]
 /// unsafe extern "C" fn strlen(s: *const c_char) -> usize {
 ///     libc!(libc::strlen(s));


### PR DESCRIPTION
Fix errors in the `use_libc` modules that prevented `cargo test --workspace` from running, and add a few unit tests for it to run.