### PR TITLE
Add finite and lgamma

### DIFF
--- a/c-scape/src/math/mod.rs
+++ b/c-scape/src/math/mod.rs
@@ -769,6 +769,16 @@ unsafe extern "C" fn isinff(x: f32) -> i32 {
     }
 }
 
+#[no_mangle]
+unsafe extern "C" fn lgamma(x: f64) -> f64 {
+    libm::lgamma(x)
+}
+
+#[no_mangle]
+unsafe extern "C" fn lgammaf(x: f32) -> f32 {
+    libm::lgammaf(x)
+}
+
 // Enable support for complex numbers only on architectures where the builtin
 // C complex type has the same calling convention rules as a struct containing
 // two scalars. Notably, this excludes 32-bit "x86".

--- a/c-scape/src/math/mod.rs
+++ b/c-scape/src/math/mod.rs
@@ -730,21 +730,21 @@ unsafe extern "C" fn nearbyintf(x: f32) -> f32 {
 
 #[no_mangle]
 unsafe extern "C" fn finite(x: f64) -> i32 {
-    return x.is_finite() as i32;
+    x.is_finite() as i32
 }
 #[no_mangle]
 unsafe extern "C" fn finitef(x: f32) -> i32 {
-    return x.is_finite() as i32;
+    x.is_finite() as i32
 }
 
 #[no_mangle]
 unsafe extern "C" fn isnan(x: f64) -> i32 {
-    return x.is_nan() as i32;
+    x.is_nan() as i32
 }
 
 #[no_mangle]
 unsafe extern "C" fn isnanf(x: f32) -> i32 {
-    return x.is_nan() as i32;
+    x.is_nan() as i32
 }
 
 #[no_mangle]

--- a/c-scape/src/math/mod.rs
+++ b/c-scape/src/math/mod.rs
@@ -728,6 +728,35 @@ unsafe extern "C" fn nearbyintf(x: f32) -> f32 {
     libm::rintf(x)
 }
 
+#[no_mangle]
+unsafe extern "C" fn finite(x: f64) -> i32 {
+    return x.is_finite() as i32;
+}
+#[no_mangle]
+unsafe extern "C" fn finitef(x: f32) -> i32 {
+    return x.is_finite() as i32;
+}
+
+#[no_mangle]
+unsafe extern "C" fn isnan(x: f64) -> i32 {
+    return x.is_nan() as i32;
+}
+
+#[no_mangle]
+unsafe extern "C" fn isnanf(x: f32) -> i32 {
+    return x.is_nan() as i32;
+}
+
+#[no_mangle]
+unsafe extern "C" fn isinf(x: f64) -> i32 {
+    return (x.is_infinite() as i32) * x.signum() as i32;
+}
+
+#[no_mangle]
+unsafe extern "C" fn isinff(x: f32) -> i32 {
+    return (x.is_infinite() as i32) * x.signum() as i32;
+}
+
 // Enable support for complex numbers only on architectures where the builtin
 // C complex type has the same calling convention rules as a struct containing
 // two scalars. Notably, this excludes 32-bit "x86".
@@ -738,3 +767,43 @@ unsafe extern "C" fn nearbyintf(x: f32) -> f32 {
     target_arch = "x86_64"
 ))]
 mod complex;
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    #[test]
+    fn is_finite_test() {
+        unsafe {
+            assert_eq!(finite(1.), 1);
+            assert_eq!(finite(f64::NAN), 0);
+            assert_eq!(finite(f64::INFINITY), 0);
+            assert_eq!(finite(f64::NEG_INFINITY), 0);
+
+            assert_eq!(isnan(1.), 0);
+            assert_eq!(isnan(f64::NAN), 1);
+            assert_eq!(isnan(f64::INFINITY), 0);
+            assert_eq!(isnan(f64::NEG_INFINITY), 0);
+
+            assert_eq!(isinf(1.), 0);
+            assert_eq!(isinf(f64::NAN), 0);
+            assert_eq!(isinf(f64::INFINITY), 1);
+            assert_eq!(isinf(f64::NEG_INFINITY), -1);
+
+            assert_eq!(finitef(1.), 1);
+            assert_eq!(finitef(f32::NAN), 0);
+            assert_eq!(finitef(f32::INFINITY), 0);
+            assert_eq!(finitef(f32::NEG_INFINITY), 0);
+
+            assert_eq!(isnanf(1.), 0);
+            assert_eq!(isnanf(f32::NAN), 1);
+            assert_eq!(isnanf(f32::INFINITY), 0);
+            assert_eq!(isnanf(f32::NEG_INFINITY), 0);
+
+            assert_eq!(isinff(1.), 0);
+            assert_eq!(isinff(f32::NAN), 0);
+            assert_eq!(isinff(f32::INFINITY), 1);
+            assert_eq!(isinff(f32::NEG_INFINITY), -1);
+        }
+    }
+}

--- a/c-scape/src/math/mod.rs
+++ b/c-scape/src/math/mod.rs
@@ -770,13 +770,20 @@ unsafe extern "C" fn isinff(x: f32) -> i32 {
 }
 
 #[no_mangle]
+pub static mut signgam: i32 = 0;
+
+#[no_mangle]
 unsafe extern "C" fn lgamma(x: f64) -> f64 {
-    libm::lgamma(x)
+    let (a, b) = libm::lgamma_r(x);
+    signgam = b;
+    a
 }
 
 #[no_mangle]
 unsafe extern "C" fn lgammaf(x: f32) -> f32 {
-    libm::lgammaf(x)
+    let (res, sgn) = libm::lgammaf_r(x);
+    signgam = sgn;
+    res
 }
 
 // Enable support for complex numbers only on architectures where the builtin

--- a/c-scape/src/math/mod.rs
+++ b/c-scape/src/math/mod.rs
@@ -770,7 +770,7 @@ unsafe extern "C" fn isinff(x: f32) -> i32 {
 }
 
 #[no_mangle]
-pub static mut signgam: i32 = 0;
+static mut signgam: i32 = 0;
 
 #[no_mangle]
 unsafe extern "C" fn lgamma(x: f64) -> f64 {

--- a/c-scape/src/math/mod.rs
+++ b/c-scape/src/math/mod.rs
@@ -750,22 +750,22 @@ unsafe extern "C" fn isnanf(x: f32) -> i32 {
 #[no_mangle]
 unsafe extern "C" fn isinf(x: f64) -> i32 {
     if x == f64::INFINITY {
-        return 1;
+        1
     } else if x == f64::NEG_INFINITY {
-        return -1;
+        -1
     } else {
-        return 0;
+        0
     }
 }
 
 #[no_mangle]
 unsafe extern "C" fn isinff(x: f32) -> i32 {
     if x == f32::INFINITY {
-        return 1;
+        1
     } else if x == f32::NEG_INFINITY {
-        return -1;
+        -1
     } else {
-        return 0;
+        0
     }
 }
 

--- a/c-scape/src/math/mod.rs
+++ b/c-scape/src/math/mod.rs
@@ -749,12 +749,24 @@ unsafe extern "C" fn isnanf(x: f32) -> i32 {
 
 #[no_mangle]
 unsafe extern "C" fn isinf(x: f64) -> i32 {
-    return (x.is_infinite() as i32) * x.signum() as i32;
+    if x == f64::INFINITY {
+        return 1;
+    } else if x == f64::NEG_INFINITY {
+        return -1;
+    } else {
+        return 0;
+    }
 }
 
 #[no_mangle]
 unsafe extern "C" fn isinff(x: f32) -> i32 {
-    return (x.is_infinite() as i32) * x.signum() as i32;
+    if x == f32::INFINITY {
+        return 1;
+    } else if x == f32::NEG_INFINITY {
+        return -1;
+    } else {
+        return 0;
+    }
 }
 
 // Enable support for complex numbers only on architectures where the builtin

--- a/c-scape/src/mem/ntbs.rs
+++ b/c-scape/src/mem/ntbs.rs
@@ -99,11 +99,7 @@ unsafe extern "C" fn strchrnul(s: *const c_char, c: c_int) -> *mut c_char {
 unsafe extern "C" fn strcmp(mut s1: *const c_char, mut s2: *const c_char) -> c_int {
     libc!(libc::strcmp(s1, s2));
 
-    while *s1 != NUL && *s2 != NUL {
-        if *s1 != *s2 {
-            break;
-        }
-
+    while *s1 == *s2 && *s1 != NUL {
         s1 = s1.add(1);
         s2 = s2.add(1);
     }
@@ -216,10 +212,7 @@ impl StrverscmpState {
 unsafe extern "C" fn strverscmp(mut s1: *const c_char, mut s2: *const c_char) -> c_int {
     // libc!(libc::strverscmp(s1, s2));
     let mut state = StrverscmpState::Normal;
-    while *s1 != NUL && *s2 != NUL {
-        if *s1 != *s2 {
-            return state.exit(s1, s2);
-        }
+    while *s1 == *s2 && *s1 != NUL {
         state.transition(CharType::from_char(*s1));
         s1 = s1.add(1);
         s2 = s2.add(1);
@@ -632,13 +625,9 @@ unsafe extern "C" fn strlcat(dst: *mut c_char, src: *const c_char, limit: size_t
 #[cfg(test)]
 mod tests {
 
-    // use candle_core::test_utils::{to_vec0_round, to_vec2_round};
     use super::*;
     #[test]
     fn strverscmp_test() {
-        extern "C" {
-            fn strverscmp(a: *const libc::c_char, b: *const libc::c_char) -> libc::c_int;
-        }
         unsafe {
             assert!(strverscmp("000\0".as_ptr().cast(), "00\0".as_ptr().cast()) < 0);
             assert!(strverscmp("00\0".as_ptr().cast(), "01\0".as_ptr().cast()) < 0);

--- a/c-scape/src/todo.rs
+++ b/c-scape/src/todo.rs
@@ -1378,10 +1378,7 @@ unsafe extern "C" fn register_printf_function() {
 unsafe extern "C" fn adjtime() {
     todo!("adjtime")
 }
-#[no_mangle]
-unsafe extern "C" fn isnanf() {
-    todo!("isnanf")
-}
+
 #[no_mangle]
 unsafe extern "C" fn gamma() {
     todo!("gamma")

--- a/c-scape/src/todo.rs
+++ b/c-scape/src/todo.rs
@@ -1388,14 +1388,6 @@ unsafe extern "C" fn gammaf() {
     todo!("gammaf")
 }
 #[no_mangle]
-unsafe extern "C" fn lgamma() {
-    todo!("lgamma")
-}
-#[no_mangle]
-unsafe extern "C" fn lgammaf() {
-    todo!("lgammaf")
-}
-#[no_mangle]
 unsafe extern "C" fn strfromf() {
     todo!("strfromf")
 }


### PR DESCRIPTION
This adds the functions described in https://man7.org/linux/man-pages/man3/isnanf.3.html for `f32` and `f64` removing `isnanf()` from todo.

Implemented are

- `finite`
- `finitef`
- `isnan`
- `isnanf`
- `isinf`
- `isinff`

and the missing maths functions

-`lgamma`
-`lgammaf`
It also cleans up `strcmp` and `strverscmp` such that the break conditions are in the while condition