### PR TITLE
Testcase tidying.

### DIFF
--- a/c-gull/src/system.rs
+++ b/c-gull/src/system.rs
@@ -30,14 +30,19 @@ fn _system(command: &OsStr) -> c_int {
     }
 }
 
-#[test]
-fn test_system() {
-    unsafe {
-        use rustix::cstr;
-        assert_eq!(system(core::ptr::null()), 1);
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-        let t = system(cstr!("/bin/sh -c exit\\ 42").as_ptr());
-        assert!(libc::WIFEXITED(t));
-        assert_eq!(libc::WEXITSTATUS(t), 42);
+    #[test]
+    fn test_system() {
+        unsafe {
+            use rustix::cstr;
+            assert_eq!(system(core::ptr::null()), 1);
+
+            let t = system(cstr!("/bin/sh -c exit\\ 42").as_ptr());
+            assert!(libc::WIFEXITED(t));
+            assert_eq!(libc::WEXITSTATUS(t), 42);
+        }
     }
 }

--- a/c-scape/src/path/mod.rs
+++ b/c-scape/src/path/mod.rs
@@ -112,43 +112,48 @@ unsafe extern "C" fn dirname(path: *mut c_char) -> *mut c_char {
     path
 }
 
-#[test]
-fn test_dirname_basename() {
-    use core::ffi::CStr;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    fn test(input: &CStr, expected_dir: &CStr, expected_gnu: &CStr, expected_posix: &CStr) {
-        unsafe {
-            let mut s = input.to_bytes_with_nul().to_vec();
-            let i = s.as_mut_ptr().cast();
-            let o = libc::dirname(i);
-            assert_eq!(CStr::from_ptr(o), expected_dir);
+    #[test]
+    fn test_dirname_basename() {
+        use core::ffi::CStr;
 
-            let mut s = input.to_bytes_with_nul().to_vec();
-            let i = s.as_mut_ptr().cast();
-            let o = libc::gnu_basename(i);
-            assert_eq!(CStr::from_ptr(o), expected_gnu);
+        fn test(input: &CStr, expected_dir: &CStr, expected_gnu: &CStr, expected_posix: &CStr) {
+            unsafe {
+                let mut s = input.to_bytes_with_nul().to_vec();
+                let i = s.as_mut_ptr().cast();
+                let o = libc::dirname(i);
+                assert_eq!(CStr::from_ptr(o), expected_dir);
 
-            let mut s = input.to_bytes_with_nul().to_vec();
-            let i = s.as_mut_ptr().cast();
-            let o = libc::posix_basename(i);
-            assert_eq!(CStr::from_ptr(o), expected_posix);
+                let mut s = input.to_bytes_with_nul().to_vec();
+                let i = s.as_mut_ptr().cast();
+                let o = libc::gnu_basename(i);
+                assert_eq!(CStr::from_ptr(o), expected_gnu);
+
+                let mut s = input.to_bytes_with_nul().to_vec();
+                let i = s.as_mut_ptr().cast();
+                let o = libc::posix_basename(i);
+                assert_eq!(CStr::from_ptr(o), expected_posix);
+            }
         }
-    }
 
-    test(cstr!("/usr/lib"), cstr!("/usr"), cstr!("lib"), cstr!("lib"));
-    test(
-        cstr!("/usr//lib"),
-        cstr!("/usr"),
-        cstr!("lib"),
-        cstr!("lib"),
-    );
-    test(cstr!("/usr/lib/"), cstr!("/usr"), cstr!(""), cstr!("lib"));
-    test(cstr!("/usr/lib//"), cstr!("/usr"), cstr!(""), cstr!("lib"));
-    test(cstr!("/"), cstr!("/"), cstr!(""), cstr!("/"));
-    test(cstr!("//"), cstr!("//"), cstr!(""), cstr!("/"));
-    test(cstr!("///"), cstr!("/"), cstr!(""), cstr!("/"));
-    test(cstr!(""), cstr!("."), cstr!(""), cstr!("."));
-    test(cstr!("usr"), cstr!("."), cstr!("usr"), cstr!("usr"));
-    test(cstr!("usr/"), cstr!("."), cstr!(""), cstr!("usr"));
-    test(cstr!("usr//"), cstr!("."), cstr!(""), cstr!("usr"));
+        test(cstr!("/usr/lib"), cstr!("/usr"), cstr!("lib"), cstr!("lib"));
+        test(
+            cstr!("/usr//lib"),
+            cstr!("/usr"),
+            cstr!("lib"),
+            cstr!("lib"),
+        );
+        test(cstr!("/usr/lib/"), cstr!("/usr"), cstr!(""), cstr!("lib"));
+        test(cstr!("/usr/lib//"), cstr!("/usr"), cstr!(""), cstr!("lib"));
+        test(cstr!("/"), cstr!("/"), cstr!(""), cstr!("/"));
+        test(cstr!("//"), cstr!("//"), cstr!(""), cstr!("/"));
+        test(cstr!("///"), cstr!("/"), cstr!(""), cstr!("/"));
+        test(cstr!(""), cstr!("."), cstr!(""), cstr!("."));
+        test(cstr!("usr"), cstr!("."), cstr!("usr"), cstr!("usr"));
+        test(cstr!("usr/"), cstr!("."), cstr!(""), cstr!("usr"));
+        test(cstr!("usr//"), cstr!("."), cstr!(""), cstr!("usr"));
+    }
 }

--- a/c-scape/src/rand_.rs
+++ b/c-scape/src/rand_.rs
@@ -55,16 +55,21 @@ unsafe extern "C" fn getentropy(ptr: *mut c_void, len: usize) -> i32 {
     0
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
-#[test]
-fn test_getentropy() {
-    unsafe {
-        let mut buf = [0; 257];
-        assert_eq!(getentropy(buf.as_mut_ptr().cast(), 257), -1);
-        assert_eq!(errno::errno().0, libc::EIO);
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-        let mut buf = [0; 257];
-        assert_eq!(getentropy(buf.as_mut_ptr().cast(), 256), 0);
-        assert!(buf.iter().any(|b| *b != 0));
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[test]
+    fn test_getentropy() {
+        unsafe {
+            let mut buf = [0; 257];
+            assert_eq!(getentropy(buf.as_mut_ptr().cast(), 257), -1);
+            assert_eq!(errno::errno().0, libc::EIO);
+
+            let mut buf = [0; 257];
+            assert_eq!(getentropy(buf.as_mut_ptr().cast(), 256), 0);
+            assert!(buf.iter().any(|b| *b != 0));
+        }
     }
 }

--- a/c-scape/src/stdio.rs
+++ b/c-scape/src/stdio.rs
@@ -981,31 +981,36 @@ unsafe extern "C" fn perror(user_message: *const c_char) {
     }
 }
 
-#[test]
-fn test_fputs() {
-    use core::ptr::null_mut;
-    use rustix::cstr;
-    unsafe {
-        let mut buf = [0u8; 8];
-        let fd = libc::memfd_create(cstr!("test").as_ptr(), 0);
-        assert_ne!(fd, -1);
-        let file = fdopen(fd, cstr!("w").as_ptr());
-        assert_ne!(file, null_mut());
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-        assert!(fputs(cstr!("").as_ptr(), file) >= 0);
-        assert!(fflush(file) == 0);
-        assert_eq!(libc::pread(fd, buf.as_mut_ptr().cast(), buf.len(), 0), 0);
-        assert_eq!(buf, [0u8; 8]);
+    #[test]
+    fn test_fputs() {
+        use core::ptr::null_mut;
+        use rustix::cstr;
+        unsafe {
+            let mut buf = [0u8; 8];
+            let fd = libc::memfd_create(cstr!("test").as_ptr(), 0);
+            assert_ne!(fd, -1);
+            let file = fdopen(fd, cstr!("w").as_ptr());
+            assert_ne!(file, null_mut());
 
-        assert!(fputs(cstr!("hi").as_ptr(), file) >= 0);
-        assert!(fflush(file) == 0);
-        assert_eq!(libc::pread(fd, buf.as_mut_ptr().cast(), buf.len(), 0), 2);
-        assert_eq!(&buf, b"hi\0\0\0\0\0\0");
+            assert!(fputs(cstr!("").as_ptr(), file) >= 0);
+            assert!(fflush(file) == 0);
+            assert_eq!(libc::pread(fd, buf.as_mut_ptr().cast(), buf.len(), 0), 0);
+            assert_eq!(buf, [0u8; 8]);
 
-        assert!(fputs(cstr!("hello\n").as_ptr(), file) >= 0);
-        assert!(fflush(file) == 0);
-        assert_eq!(libc::pread(fd, buf.as_mut_ptr().cast(), buf.len(), 2), 6);
-        assert_eq!(&buf, b"hello\n\0\0");
+            assert!(fputs(cstr!("hi").as_ptr(), file) >= 0);
+            assert!(fflush(file) == 0);
+            assert_eq!(libc::pread(fd, buf.as_mut_ptr().cast(), buf.len(), 0), 2);
+            assert_eq!(&buf, b"hi\0\0\0\0\0\0");
+
+            assert!(fputs(cstr!("hello\n").as_ptr(), file) >= 0);
+            assert!(fflush(file) == 0);
+            assert_eq!(libc::pread(fd, buf.as_mut_ptr().cast(), buf.len(), 2), 6);
+            assert_eq!(&buf, b"hello\n\0\0");
+        }
     }
 
     #[test]

--- a/c-scape/src/syscall.rs
+++ b/c-scape/src/syscall.rs
@@ -212,31 +212,34 @@ unsafe fn futex(
     }
 }
 
-#[cfg(feature = "syscall-utimensat")]
-#[test]
-fn test_syscall_utimensat() {
-    use core::ptr::null_mut;
-    use rustix::cstr;
-    use rustix::fd::BorrowedFd;
-    unsafe {
-        let fd = libc::memfd_create(cstr!("test").as_ptr(), 0);
-        assert_ne!(fd, -1);
-        let times = [
-            libc::timespec {
-                tv_sec: 43,
-                tv_nsec: 44,
-            },
-            libc::timespec {
-                tv_sec: 45,
-                tv_nsec: 46,
-            },
-        ];
-        assert_eq!(
-            syscall(libc::SYS_utimensat, fd, null::<u8>(), &times, 0),
-            null_mut()
-        );
-        let stat = rustix::fs::fstat(BorrowedFd::borrow_raw(fd)).unwrap();
-        assert_eq!(stat.st_mtime, times[1].tv_sec as _);
-        assert_eq!(stat.st_mtime_nsec, times[1].tv_nsec as _);
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "syscall-utimensat")]
+    #[test]
+    fn test_syscall_utimensat() {
+        use core::ptr::null_mut;
+        use rustix::cstr;
+        use rustix::fd::BorrowedFd;
+        unsafe {
+            let fd = libc::memfd_create(cstr!("test").as_ptr(), 0);
+            assert_ne!(fd, -1);
+            let times = [
+                libc::timespec {
+                    tv_sec: 43,
+                    tv_nsec: 44,
+                },
+                libc::timespec {
+                    tv_sec: 45,
+                    tv_nsec: 46,
+                },
+            ];
+            assert_eq!(
+                syscall(libc::SYS_utimensat, fd, null::<u8>(), &times, 0),
+                null_mut()
+            );
+            let stat = rustix::fs::fstat(BorrowedFd::borrow_raw(fd)).unwrap();
+            assert_eq!(stat.st_mtime, times[1].tv_sec as _);
+            assert_eq!(stat.st_mtime_nsec, times[1].tv_nsec as _);
+        }
     }
 }


### PR DESCRIPTION
Put test functions in `tests` modules, following common Rust conventions.