### PR TITLE
Fchownat, ptsname and fstatfs

### DIFF
--- a/c-scape/src/fs/fchown.rs
+++ b/c-scape/src/fs/fchown.rs
@@ -1,6 +1,5 @@
 use crate::convert_res;
 use core::ffi::CStr;
-use errno::{set_errno, Errno};
 use libc::{c_char, c_int, c_uint};
 use rustix::fd::BorrowedFd;
 use rustix::fs::AtFlags;

--- a/c-scape/src/fs/fchown.rs
+++ b/c-scape/src/fs/fchown.rs
@@ -18,14 +18,10 @@ unsafe extern "C" fn fchownat(
     let pathname = CStr::from_ptr(pathname);
     let owner = Some(rustix::process::Uid::from_raw(owner));
     let group = Some(rustix::process::Gid::from_raw(group));
-    if let Some(flags) = AtFlags::from_bits(flags as c_uint) {
-        let dirfd = BorrowedFd::borrow_raw(dirfd);
-        match convert_res(rustix::fs::chownat(dirfd, pathname, owner, group, flags)) {
-            Some(()) => 0,
-            None => -1,
-        }
-    } else {
-        set_errno(Errno(libc::EINVAL));
-        -1
+    let flags = AtFlags::from_bits_retain(flags as c_uint);
+    let dirfd = BorrowedFd::borrow_raw(dirfd);
+    match convert_res(rustix::fs::chownat(dirfd, pathname, owner, group, flags)) {
+        Some(()) => 0,
+        None => -1,
     }
 }

--- a/c-scape/src/fs/fchown.rs
+++ b/c-scape/src/fs/fchown.rs
@@ -1,0 +1,26 @@
+use crate::convert_res;
+use core::ffi::CStr;
+use libc::{c_char, c_int, c_uint};
+use rustix::fd::BorrowedFd;
+use rustix::fs::AtFlags;
+
+#[no_mangle]
+unsafe extern "C" fn fchownat(
+    dirfd: c_int,
+    pathname: *const c_char,
+    owner: libc::uid_t,
+    group: libc::gid_t,
+    flags: c_int,
+) -> c_int {
+    libc!(libc::fchownat(dirfd, pathname, owner, group, flags));
+
+    let pathname = CStr::from_ptr(pathname);
+    let owner = Some(rustix::process::Uid::from_raw(owner));
+    let group = Some(rustix::process::Gid::from_raw(group));
+    let flags = AtFlags::from_bits(flags as c_uint).unwrap();
+    let dirfd = BorrowedFd::borrow_raw(dirfd);
+    match convert_res(rustix::fs::chownat(dirfd, pathname, owner, group, flags)) {
+        Some(()) => 0,
+        None => -1,
+    }
+}

--- a/c-scape/src/fs/mod.rs
+++ b/c-scape/src/fs/mod.rs
@@ -4,6 +4,7 @@ mod chmod;
 mod dir;
 mod fadvise;
 mod fallocate;
+mod fchown;
 mod fcntl;
 mod flock;
 mod inotify;

--- a/c-scape/src/termios_/mod.rs
+++ b/c-scape/src/termios_/mod.rs
@@ -589,6 +589,7 @@ unsafe extern "C" fn ptsname_r(fd: c_int, buf: *mut c_char, buflen: libc::size_t
                 0
             }
         } else {
+            set_errno(Errno(libc::ENOTTY));
             -1
         }
     }

--- a/c-scape/src/termios_/mod.rs
+++ b/c-scape/src/termios_/mod.rs
@@ -561,8 +561,7 @@ unsafe extern "C" fn ptsname(fd: c_int) -> *mut c_char {
 unsafe extern "C" fn ptsname_r(fd: c_int, buf: *mut c_char, buflen: libc::size_t) -> c_int {
     libc!(libc::ptsname_r(fd, buf, buflen));
     if buf.is_null() {
-        set_errno(Errno(libc::EINVAL));
-        -1
+        Errno(libc::EINVAL).into()
     } else {
         let fd = BorrowedFd::borrow_raw(fd);
         match rustix::pty::ptsname(fd, []) {

--- a/c-scape/src/todo.rs
+++ b/c-scape/src/todo.rs
@@ -356,14 +356,6 @@ unsafe extern "C" fn ptrace() {
     todo!("ptrace")
 }
 #[no_mangle]
-unsafe extern "C" fn ptsname() {
-    todo!("ptsname")
-}
-#[no_mangle]
-unsafe extern "C" fn ptsname_r() {
-    todo!("ptsname_r")
-}
-#[no_mangle]
 unsafe extern "C" fn forkpty() {
     todo!("forkpty")
 }

--- a/c-scape/src/todo.rs
+++ b/c-scape/src/todo.rs
@@ -49,14 +49,6 @@ unsafe extern "C" fn eaccess() {
     todo!("eaccess")
 }
 #[no_mangle]
-unsafe extern "C" fn fstatfs() {
-    todo!("fstatfs")
-}
-#[no_mangle]
-unsafe extern "C" fn fstatfs64() {
-    todo!("fstatfs64")
-}
-#[no_mangle]
 unsafe extern "C" fn timerfd_gettime() {
     todo!("timerfd_gettime")
 }

--- a/c-scape/src/todo.rs
+++ b/c-scape/src/todo.rs
@@ -49,10 +49,6 @@ unsafe extern "C" fn eaccess() {
     todo!("eaccess")
 }
 #[no_mangle]
-unsafe extern "C" fn fchownat() {
-    todo!("fchownat")
-}
-#[no_mangle]
 unsafe extern "C" fn fstatfs() {
     todo!("fstatfs")
 }


### PR DESCRIPTION
Adds implementations of 
-`fchownat` #113 
-`ptsname` #112 
-`ptsname_r`
-`fstatfs`
-`fstatfs64`

The static buffer for `ptsname` is 30 chars as in GLibC (https://codebrowser.dev/glibc/glibc/sysdeps/unix/sysv/linux/ptsname.c.html), as is the behaviour of returning a null pointer on error