### PR TITLE
Fix deprecation warnings on `st_mtime` etc.

### DIFF
--- a/c-gull/Cargo.toml
+++ b/c-gull/Cargo.toml
@@ -18,7 +18,7 @@ libc = { version = "0.2.138", default-features = false }
 c-scape = { path = "../c-scape", version = "0.15.40", default-features = false }
 errno = { version = "0.3.3", default-features = false, optional = true }
 tz-rs = { version = "0.6.11", default-features = false, optional = true }
-rustix = { version = "0.38.23", default-features = false, optional = true, features = ["fs", "itoa", "net", "param", "process", "procfs", "rand", "termios", "thread", "time"] }
+rustix = { version = "0.38.31", default-features = false, optional = true, features = ["fs", "itoa", "net", "param", "process", "procfs", "rand", "termios", "thread", "time"] }
 
 [features]
 default = ["thread", "std", "coexist-with-libc", "threadsafe-setenv", "use-compiler-builtins"]

--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -19,7 +19,7 @@ cc = { version = "1.0.68", optional = true }
 
 [dependencies]
 libm = "0.2.1"
-rustix = { version = "0.38.27", default-features = false, features = ["event", "fs", "itoa", "mm", "net", "param", "pipe", "process", "rand", "runtime", "shm", "stdio", "system", "termios", "thread", "time"] }
+rustix = { version = "0.38.31", default-features = false, features = ["event", "fs", "itoa", "mm", "net", "param", "pipe", "process", "rand", "runtime", "shm", "stdio", "system", "termios", "thread", "time"] }
 rustix-futex-sync = { version = "0.2.1", features = ["atomic_usize"] }
 memoffset = "0.9.0"
 realpath-ext = { version = "0.1.0", default-features = false }

--- a/c-scape/src/fs/stat.rs
+++ b/c-scape/src/fs/stat.rs
@@ -5,7 +5,7 @@ use core::ptr::{addr_of, addr_of_mut, copy_nonoverlapping};
 use errno::{set_errno, Errno};
 use libc::{c_char, c_int, time_t};
 use rustix::fd::BorrowedFd;
-use rustix::fs::AtFlags;
+use rustix::fs::{AtFlags, StatExt};
 
 use crate::convert_res;
 
@@ -24,11 +24,11 @@ fn rustix_stat_to_libc_stat(
     stat.st_size = rustix_stat.st_size.try_into()?;
     stat.st_blksize = rustix_stat.st_blksize.try_into()?;
     stat.st_blocks = rustix_stat.st_blocks.try_into()?;
-    stat.st_atime = rustix_stat.st_atime.try_into()?;
+    stat.st_atime = rustix_stat.atime().try_into()?;
     stat.st_atime_nsec = rustix_stat.st_atime_nsec.try_into()?;
-    stat.st_mtime = rustix_stat.st_mtime.try_into()?;
+    stat.st_mtime = rustix_stat.mtime().try_into()?;
     stat.st_mtime_nsec = rustix_stat.st_mtime_nsec.try_into()?;
-    stat.st_ctime = rustix_stat.st_ctime as time_t;
+    stat.st_ctime = rustix_stat.ctime() as time_t;
     stat.st_ctime_nsec = rustix_stat.st_ctime_nsec.try_into()?;
     Ok(stat)
 }


### PR DESCRIPTION
To handle negative timestamps, rustix now provides extension trait methods to access these fields.