### PR TITLE
Switch from `rustix::cstr` to `c""` string literals.

### DIFF
--- a/c-gull/src/nss.rs
+++ b/c-gull/src/nss.rs
@@ -14,7 +14,6 @@ use core::str;
 use core::str::FromStr;
 use errno::{set_errno, Errno};
 use libc::{c_char, c_int, c_void, gid_t, group, passwd, size_t, uid_t};
-use rustix::cstr;
 use rustix::path::DecInt;
 use std::ffi::OsStr;
 use std::os::unix::ffi::OsStrExt;
@@ -776,9 +775,9 @@ unsafe fn getserv_r(
         }
         proto
     } else if protocol == "tcp" {
-        cstr!("tcp").as_ptr()
+        c"tcp".as_ptr()
     } else if protocol == "udp" {
-        cstr!("udp").as_ptr()
+        c"udp".as_ptr()
     } else {
         return libc::EINVAL;
     }

--- a/c-gull/src/system.rs
+++ b/c-gull/src/system.rs
@@ -37,10 +37,9 @@ mod tests {
     #[test]
     fn test_system() {
         unsafe {
-            use rustix::cstr;
             assert_eq!(system(core::ptr::null()), 1);
 
-            let t = system(cstr!("/bin/sh -c exit\\ 42").as_ptr());
+            let t = system(c"/bin/sh -c exit\\ 42".as_ptr());
             assert!(libc::WIFEXITED(t));
             assert_eq!(libc::WEXITSTATUS(t), 42);
         }

--- a/c-scape/src/glibc_versioning.rs
+++ b/c-scape/src/glibc_versioning.rs
@@ -1,5 +1,4 @@
 use libc::c_char;
-use rustix::cstr;
 
 #[no_mangle]
 unsafe extern "C" fn gnu_get_libc_version() -> *const c_char {
@@ -8,5 +7,5 @@ unsafe extern "C" fn gnu_get_libc_version() -> *const c_char {
     // which is a glibc version where `posix_spawn` doesn't handle `ENOENT`
     // as std wants, so it uses `fork`+`exec` instead, since we don't yet
     // implement `posix_spawn`.
-    cstr!("2.23").as_ptr()
+    c"2.23".as_ptr()
 }

--- a/c-scape/src/mkostemps.rs
+++ b/c-scape/src/mkostemps.rs
@@ -4,7 +4,6 @@ use errno::{set_errno, Errno};
 use libc::{c_char, c_int};
 use rand::Rng;
 use rand_core::OsRng;
-use rustix::cstr;
 use rustix::fd::IntoRawFd;
 use rustix::fs::MemfdFlags;
 
@@ -55,14 +54,14 @@ unsafe extern "C" fn tmpfile64() -> *mut libc::FILE {
     libc!(libc::tmpfile64());
 
     let fd = match convert_res(rustix::fs::memfd_create(
-        cstr!("libc::tmpfile"),
+        c"libc::tmpfile",
         MemfdFlags::empty(),
     )) {
         Some(fd) => fd,
         None => return null_mut(),
     };
     let fd = fd.into_raw_fd();
-    libc::fdopen(fd, cstr!("w+").as_ptr())
+    libc::fdopen(fd, c"w+".as_ptr())
 }
 
 #[no_mangle]

--- a/c-scape/src/path/mod.rs
+++ b/c-scape/src/path/mod.rs
@@ -1,5 +1,4 @@
 use libc::c_char;
-use rustix::cstr;
 
 const SLASH: c_char = b'/' as c_char;
 
@@ -30,7 +29,7 @@ unsafe extern "C" fn __xpg_basename(path: *mut c_char) -> *mut c_char {
     //libc!(libc::__xpg_basename(path));
 
     if path.is_null() || *path == 0 {
-        return cstr!(".").as_ptr().cast_mut();
+        return c".".as_ptr().cast_mut();
     }
 
     // Find the last slash.
@@ -69,7 +68,7 @@ unsafe extern "C" fn dirname(path: *mut c_char) -> *mut c_char {
     libc!(libc::dirname(path));
 
     if path.is_null() {
-        return cstr!(".").as_ptr().cast_mut();
+        return c".".as_ptr().cast_mut();
     }
 
     // Start at the end of the string.
@@ -104,7 +103,7 @@ unsafe extern "C" fn dirname(path: *mut c_char) -> *mut c_char {
 
     // If there was no dir name, return ".".
     if i == 0 {
-        return cstr!(".").as_ptr().cast_mut();
+        return c".".as_ptr().cast_mut();
     }
 
     // Terminate the string at the end of the dirname and return it.
@@ -139,21 +138,16 @@ mod tests {
             }
         }
 
-        test(cstr!("/usr/lib"), cstr!("/usr"), cstr!("lib"), cstr!("lib"));
-        test(
-            cstr!("/usr//lib"),
-            cstr!("/usr"),
-            cstr!("lib"),
-            cstr!("lib"),
-        );
-        test(cstr!("/usr/lib/"), cstr!("/usr"), cstr!(""), cstr!("lib"));
-        test(cstr!("/usr/lib//"), cstr!("/usr"), cstr!(""), cstr!("lib"));
-        test(cstr!("/"), cstr!("/"), cstr!(""), cstr!("/"));
-        test(cstr!("//"), cstr!("//"), cstr!(""), cstr!("/"));
-        test(cstr!("///"), cstr!("/"), cstr!(""), cstr!("/"));
-        test(cstr!(""), cstr!("."), cstr!(""), cstr!("."));
-        test(cstr!("usr"), cstr!("."), cstr!("usr"), cstr!("usr"));
-        test(cstr!("usr/"), cstr!("."), cstr!(""), cstr!("usr"));
-        test(cstr!("usr//"), cstr!("."), cstr!(""), cstr!("usr"));
+        test(c"/usr/lib", c"/usr", c"lib", c"lib");
+        test(c"/usr//lib", c"/usr", c"lib", c"lib");
+        test(c"/usr/lib/", c"/usr", c"", c"lib");
+        test(c"/usr/lib//", c"/usr", c"", c"lib");
+        test(c"/", c"/", c"", c"/");
+        test(c"//", c"//", c"", c"/");
+        test(c"///", c"/", c"", c"/");
+        test(c"", c".", c"", c".");
+        test(c"usr", c".", c"usr", c"usr");
+        test(c"usr/", c".", c"", c"usr");
+        test(c"usr//", c".", c"", c"usr");
     }
 }

--- a/c-scape/src/process/daemon.rs
+++ b/c-scape/src/process/daemon.rs
@@ -1,5 +1,4 @@
 use libc::c_int;
-use rustix::cstr;
 use rustix::fd::{AsRawFd, FromRawFd, OwnedFd};
 
 #[no_mangle]
@@ -10,13 +9,13 @@ unsafe extern "C" fn daemon(nochdir: c_int, noclose: c_int) -> c_int {
     let noclose = noclose != 0;
 
     if !nochdir {
-        if libc::chdir(cstr!("/").as_ptr()) != 0 {
+        if libc::chdir(c"/".as_ptr()) != 0 {
             return -1;
         }
     }
 
     if !noclose {
-        let dev_null = libc::open(cstr!("/dev/null").as_ptr(), libc::O_RDWR);
+        let dev_null = libc::open(c"/dev/null".as_ptr(), libc::O_RDWR);
         if dev_null < 0 {
             return -1;
         }

--- a/c-scape/src/process/exec.rs
+++ b/c-scape/src/process/exec.rs
@@ -115,7 +115,7 @@ unsafe extern "C" fn execvpe(
 
     let path = crate::env::get::_getenv(b"PATH");
     let path = if path.is_null() {
-        rustix::cstr!("/bin:/usr/bin")
+        c"/bin:/usr/bin"
     } else {
         CStr::from_ptr(path)
     };
@@ -200,7 +200,7 @@ unsafe extern "C" fn fexecve(
 
     let mut error = rustix::runtime::execveat(
         BorrowedFd::borrow_raw(fd),
-        rustix::cstr!(""),
+        c"",
         argv as *const *const _,
         envp as *const *const _,
         AtFlags::EMPTY_PATH,

--- a/c-scape/src/process_.rs
+++ b/c-scape/src/process_.rs
@@ -6,7 +6,6 @@ use core::ptr;
 use core::ptr::{addr_of, null_mut};
 use errno::{set_errno, Errno};
 use libc::{c_char, c_int, c_long, c_ulong, c_void};
-use rustix::cstr;
 
 #[no_mangle]
 unsafe extern "C" fn getpagesize() -> c_int {
@@ -216,7 +215,7 @@ unsafe extern "C" fn dl_iterate_phdr(
     let (phdr, _phent, phnum) = rustix::runtime::exe_phdrs();
     let mut info = libc::dl_phdr_info {
         dlpi_addr: addr_of!(__executable_start).expose_addr() as _,
-        dlpi_name: cstr!("/proc/self/exe").as_ptr(),
+        dlpi_name: c"/proc/self/exe".as_ptr(),
         dlpi_phdr: phdr.cast(),
         dlpi_phnum: phnum.try_into().unwrap(),
         ..zeroed()

--- a/c-scape/src/signal/mod.rs
+++ b/c-scape/src/signal/mod.rs
@@ -3,7 +3,6 @@ use core::mem::{align_of, size_of, size_of_val, transmute, zeroed};
 use core::ptr::{addr_of, addr_of_mut, copy_nonoverlapping};
 use errno::{set_errno, Errno};
 use libc::*;
-use rustix::cstr;
 use rustix::process::Signal;
 use rustix::runtime::{How, Sigaction, Siginfo, Sigset, Stack};
 
@@ -410,41 +409,41 @@ unsafe extern "C" fn strsignal(sig: c_int) -> *mut c_char {
 
     let sig = match Signal::from_raw(sig) {
         Some(sig) => sig,
-        None => return cstr!("Unknown signal").as_ptr() as _,
+        None => return c"Unknown signal".as_ptr() as _,
     };
 
     match sig {
-        Signal::Abort => cstr!("Process abort signal").as_ptr() as _,
-        Signal::Alarm => cstr!("Alarm clock").as_ptr() as _,
-        Signal::Bus => cstr!("Access to an undefined portion of a memory object").as_ptr() as _,
-        Signal::Child => cstr!("Child process terminated, stopped, or continued").as_ptr() as _,
-        Signal::Cont => cstr!("Continue executing, if stopped").as_ptr() as _,
-        Signal::Fpe => cstr!("Erroneous arithmetic operation").as_ptr() as _,
-        Signal::Hup => cstr!("Hangup").as_ptr() as _,
-        Signal::Ill => cstr!("Invalid instruction").as_ptr() as _,
-        Signal::Int => cstr!("Terminal interrupt signal").as_ptr() as _,
-        Signal::Kill => cstr!("Kill (cannot be caught or ignored)").as_ptr() as _,
-        Signal::Pipe => cstr!("Write on a pipe with no one to read it").as_ptr() as _,
-        Signal::Quit => cstr!("Terminal quit signal").as_ptr() as _,
-        Signal::Segv => cstr!("Invalid memory reference").as_ptr() as _,
-        Signal::Stop => cstr!("Stop executing (cannot be caught or ignored)").as_ptr() as _,
-        Signal::Term => cstr!("Termination signal").as_ptr() as _,
-        Signal::Tstp => cstr!("Terminal stop signal").as_ptr() as _,
-        Signal::Ttin => cstr!("Background process attempting read").as_ptr() as _,
-        Signal::Ttou => cstr!("Background process attempting write").as_ptr() as _,
-        Signal::Usr1 => cstr!("User-defined signal 1").as_ptr() as _,
-        Signal::Usr2 => cstr!("User-defined signal 2").as_ptr() as _,
-        Signal::Prof => cstr!("Profiling timer expired").as_ptr() as _,
-        Signal::Sys => cstr!("Bad system call").as_ptr() as _,
-        Signal::Trap => cstr!("Trace/breakpoint trap").as_ptr() as _,
-        Signal::Urg => cstr!("High bandwidth data is available at a socket").as_ptr() as _,
-        Signal::Vtalarm => cstr!("Virtual timer expired").as_ptr() as _,
-        Signal::Xcpu => cstr!("CPU time limit exceeded").as_ptr() as _,
-        Signal::Xfsz => cstr!("File size limit exceeded").as_ptr() as _,
-        Signal::Io => cstr!("I/O now possible").as_ptr() as _,
-        Signal::Stkflt => cstr!("Stack fault on coprocessor").as_ptr() as _,
-        Signal::Winch => cstr!("Window resize signal").as_ptr() as _,
-        Signal::Power => cstr!("Power failure").as_ptr() as _,
+        Signal::Abort => c"Process abort signal".as_ptr() as _,
+        Signal::Alarm => c"Alarm clock".as_ptr() as _,
+        Signal::Bus => c"Access to an undefined portion of a memory object".as_ptr() as _,
+        Signal::Child => c"Child process terminated, stopped, or continued".as_ptr() as _,
+        Signal::Cont => c"Continue executing, if stopped".as_ptr() as _,
+        Signal::Fpe => c"Erroneous arithmetic operation".as_ptr() as _,
+        Signal::Hup => c"Hangup".as_ptr() as _,
+        Signal::Ill => c"Invalid instruction".as_ptr() as _,
+        Signal::Int => c"Terminal interrupt signal".as_ptr() as _,
+        Signal::Kill => c"Kill (cannot be caught or ignored)".as_ptr() as _,
+        Signal::Pipe => c"Write on a pipe with no one to read it".as_ptr() as _,
+        Signal::Quit => c"Terminal quit signal".as_ptr() as _,
+        Signal::Segv => c"Invalid memory reference".as_ptr() as _,
+        Signal::Stop => c"Stop executing (cannot be caught or ignored)".as_ptr() as _,
+        Signal::Term => c"Termination signal".as_ptr() as _,
+        Signal::Tstp => c"Terminal stop signal".as_ptr() as _,
+        Signal::Ttin => c"Background process attempting read".as_ptr() as _,
+        Signal::Ttou => c"Background process attempting write".as_ptr() as _,
+        Signal::Usr1 => c"User-defined signal 1".as_ptr() as _,
+        Signal::Usr2 => c"User-defined signal 2".as_ptr() as _,
+        Signal::Prof => c"Profiling timer expired".as_ptr() as _,
+        Signal::Sys => c"Bad system call".as_ptr() as _,
+        Signal::Trap => c"Trace/breakpoint trap".as_ptr() as _,
+        Signal::Urg => c"High bandwidth data is available at a socket".as_ptr() as _,
+        Signal::Vtalarm => c"Virtual timer expired".as_ptr() as _,
+        Signal::Xcpu => c"CPU time limit exceeded".as_ptr() as _,
+        Signal::Xfsz => c"File size limit exceeded".as_ptr() as _,
+        Signal::Io => c"I/O now possible".as_ptr() as _,
+        Signal::Stkflt => c"Stack fault on coprocessor".as_ptr() as _,
+        Signal::Winch => c"Window resize signal".as_ptr() as _,
+        Signal::Power => c"Power failure".as_ptr() as _,
     }
 }
 

--- a/c-scape/src/strtol.rs
+++ b/c-scape/src/strtol.rs
@@ -182,12 +182,11 @@ mod tests {
     use super::*;
     use core::ptr::null_mut;
     use errno::errno;
-    use rustix::cstr;
 
     #[test]
     fn test_strtol() {
         unsafe {
-            assert_eq!(strtol(cstr!("45").as_ptr(), null_mut(), 37), 0);
+            assert_eq!(strtol(c"45".as_ptr(), null_mut(), 37), 0);
             assert_eq!(errno().0, libc::EINVAL);
         }
     }

--- a/c-scape/src/syscall.rs
+++ b/c-scape/src/syscall.rs
@@ -224,10 +224,9 @@ mod tests {
     #[test]
     fn test_syscall_utimensat() {
         use core::ptr::null_mut;
-        use rustix::cstr;
         use rustix::fd::BorrowedFd;
         unsafe {
-            let fd = libc::memfd_create(cstr!("test").as_ptr(), 0);
+            let fd = libc::memfd_create(c"test".as_ptr(), 0);
             assert_ne!(fd, -1);
             let times = [
                 libc::timespec {


### PR DESCRIPTION
Rust now has a C string literal syntax.