### PR TITLE
Add AT_MINSIGSTKSZ support for getauxval()

### DIFF
--- a/c-scape/src/process_.rs
+++ b/c-scape/src/process_.rs
@@ -187,9 +187,12 @@ unsafe extern "C" fn __getauxval(type_: c_ulong) -> *mut c_void {
 
 #[cfg(feature = "take-charge")]
 fn _getauxval(type_: c_ulong) -> *mut c_void {
+    // FIXME: reuse const from libc when available?
+    const AT_MINSIGSTKSZ: c_ulong = 51;
     match type_ {
         libc::AT_HWCAP => ptr::without_provenance_mut(rustix::param::linux_hwcap().0),
         libc::AT_HWCAP2 => ptr::without_provenance_mut(rustix::param::linux_hwcap().1),
+        AT_MINSIGSTKSZ => ptr::without_provenance_mut(rustix::param::linux_minsigstksz()),
         _ => todo!("unrecognized __getauxval {}", type_),
     }
 }


### PR DESCRIPTION
https://github.com/rust-lang/rust/commit/9da004ea1997ac0eedbb882fa52960417725bd48 uses AT_MINSIGSTKSZ which is not supported by `c-scape`.

Waiting https://github.com/bytecodealliance/rustix/pull/1041 to be released.