### PR TITLE
Don't define stdio functions in coexist-with-libc mode.

### DIFF
--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -102,6 +102,7 @@ mod pty;
 mod rand_;
 mod regex;
 mod sort;
+#[cfg(feature = "take-charge")]
 mod stdio;
 mod strtod;
 mod strtol;


### PR DESCRIPTION
In coexist-with-libc mode, we don't control the layout of the `FILE` struct, so don't try to implement the stdio functions.