### PR TITLE
Don't panic if /var/run/utmp is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ The primary way this is used is through [Mustang] and [Eyra], as their libc
 implementations. It can also be used as a regular library in
 ["coexist-with-libc" mode].
 
+## Runtime requirements
+
+Resolving users and DNS records requires the execution of `getent` which
+prints the entries on stdout. On a regular glibc system the `getent`
+binary is provided by it and uses the NSS setup as usual.
+Similar, a musl system also provides `getent` (but does not use NSS).
+
 ## Similar crates
 
 Another libc implementation is [relibc]. [tinyrlibc] is a very minimal set of

--- a/c-gull/src/utmp.rs
+++ b/c-gull/src/utmp.rs
@@ -22,9 +22,12 @@ unsafe extern "C" fn getutxent() -> *mut libc::utmpx {
 
     ensure_open_file(&mut lock);
 
-    let (_path, file, entry) = lock.get_mut().unwrap();
+    let (_path, Some(ref mut file), entry) = lock.get_mut().unwrap() else {
+        set_errno(Errno(libc::ENOENT));
+        return null_mut();
+    };
 
-    match file.as_ref().unwrap().read_exact(unsafe {
+    match file.read_exact(unsafe {
         slice::from_raw_parts_mut(entry as *mut utmpx as *mut u8, size_of::<utmpx>())
     }) {
         Ok(()) => entry,
@@ -43,10 +46,13 @@ unsafe extern "C" fn getutxid(ut: *const libc::utmpx) -> *mut libc::utmpx {
 
     ensure_open_file(&mut lock);
 
-    let (_path, file, entry) = lock.get_mut().unwrap();
+    let (_path, Some(ref mut file), entry) = lock.get_mut().unwrap() else {
+        set_errno(Errno(libc::ENOENT));
+        return null_mut();
+    };
 
     loop {
-        match file.as_ref().unwrap().read_exact(unsafe {
+        match file.read_exact(unsafe {
             slice::from_raw_parts_mut(entry as *mut utmpx as *mut u8, size_of::<utmpx>())
         }) {
             Ok(()) => {}
@@ -80,10 +86,13 @@ unsafe extern "C" fn getutxline(ut: *const libc::utmpx) -> *mut libc::utmpx {
 
     ensure_open_file(&mut lock);
 
-    let (_path, file, entry) = lock.get_mut().unwrap();
+    let (_path, Some(ref mut file), entry) = lock.get_mut().unwrap() else {
+        set_errno(Errno(libc::ENOENT));
+        return null_mut();
+    };
 
     loop {
-        match file.as_ref().unwrap().read_exact(unsafe {
+        match file.read_exact(unsafe {
             slice::from_raw_parts_mut(entry as *mut utmpx as *mut u8, size_of::<utmpx>())
         }) {
             Ok(()) => {}


### PR DESCRIPTION
- Don't panic if /var/run/utmp is missing
    In a container as set up by Podman there is no utmp file in (/var)/run.
    When no file is present, we can return NULL.
- Document requirements for runtime environment. (Based on the above this is only about `getent`.)
