### PR TITLE
Use origin's errno_location in the __errno_location implementation

### DIFF
--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -64,7 +64,7 @@ static_assertions = "1.1.0"
 
 [features]
 default = ["thread", "std", "coexist-with-libc", "threadsafe-setenv", "use-compiler-builtins"]
-thread = []
+thread = ["origin/unstable-errno"]
 std = ["rustix/std", "printf-compat/std"]
 
 # In "take-charge" mode, this enables code in c-scape to define the


### PR DESCRIPTION
This will help with integrating the musl dynamic linker until a rust replacement is written.

cc sunfishcode/origin#110