### PR TITLE
Update to the latest Rust nightly.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,3 @@ members = [
   "c-scape",
   "c-gull",
 ]
-
-# TODO: Remove this workaround when
-# https://github.com/llvm/llvm-project/pull/105513
-# makes it into the Rust compiler.
-[profile.dev.package.unwinding]
-debug = false

--- a/c-scape/src/arpa_inet.rs
+++ b/c-scape/src/arpa_inet.rs
@@ -1,4 +1,5 @@
 use alloc::string::ToString;
+use core::cell::SyncUnsafeCell;
 use core::ffi::CStr;
 use core::net::{Ipv4Addr, Ipv6Addr};
 use core::ptr::{addr_of, copy_nonoverlapping, null};
@@ -16,13 +17,14 @@ unsafe extern "C" fn inet_aton(cp: *const c_char, inp: *mut in_addr) -> c_int {
 unsafe extern "C" fn inet_ntoa(in_: in_addr) -> *const c_char {
     //libc!(libc::inet_ntoa(in_));
 
-    static mut BUFFER: [c_char; 16] = [0; 16];
+    static BUFFER: SyncUnsafeCell<[c_char; 16]> = SyncUnsafeCell::new([0; 16]);
+    let buffer = &mut *BUFFER.get();
 
     inet_ntop(
         libc::AF_INET,
         addr_of!(in_).cast::<c_void>(),
-        BUFFER.as_mut_ptr(),
-        BUFFER.len() as _,
+        buffer.as_mut_ptr(),
+        buffer.len() as _,
     )
 }
 

--- a/example-crates/c-gull-example/Cargo.toml
+++ b/example-crates/c-gull-example/Cargo.toml
@@ -20,9 +20,3 @@ package = "c-gull"
 
 # This is just an example crate, and not part of the c-ward workspace.
 [workspace]
-
-# TODO: Remove this workaround when
-# https://github.com/llvm/llvm-project/pull/105513
-# makes it into the Rust compiler.
-[profile.dev.package.unwinding]
-debug = false

--- a/example-crates/c-gull-lto/Cargo.toml
+++ b/example-crates/c-gull-lto/Cargo.toml
@@ -23,9 +23,3 @@ lto = true
 
 # This is just an example crate, and not part of the c-ward workspace.
 [workspace]
-
-# TODO: Remove this workaround when
-# https://github.com/llvm/llvm-project/pull/105513
-# makes it into the Rust compiler.
-[profile.dev.package.unwinding]
-debug = false

--- a/example-crates/c-scape-example/Cargo.toml
+++ b/example-crates/c-scape-example/Cargo.toml
@@ -24,9 +24,3 @@ rustix-dlmalloc = { version = "0.1.0", features = ["global"] }
 
 # This is just an example crate, and not part of the c-ward workspace.
 [workspace]
-
-# TODO: Remove this workaround when
-# https://github.com/llvm/llvm-project/pull/105513
-# makes it into the Rust compiler.
-[profile.dev.package.unwinding]
-debug = false

--- a/example-crates/custom-allocator/Cargo.toml
+++ b/example-crates/custom-allocator/Cargo.toml
@@ -26,9 +26,3 @@ rustix-dlmalloc = { version = "0.1.0", features = ["global"] }
 
 # This is just an example crate, and not part of the c-ward workspace.
 [workspace]
-
-# TODO: Remove this workaround when
-# https://github.com/llvm/llvm-project/pull/105513
-# makes it into the Rust compiler.
-[profile.dev.package.unwinding]
-debug = false

--- a/example-crates/dns/Cargo.toml
+++ b/example-crates/dns/Cargo.toml
@@ -19,9 +19,3 @@ package = "c-gull"
 
 # This is just an example crate, and not part of the c-ward workspace.
 [workspace]
-
-# TODO: Remove this workaround when
-# https://github.com/llvm/llvm-project/pull/105513
-# makes it into the Rust compiler.
-[profile.dev.package.unwinding]
-debug = false

--- a/example-crates/libc-replacement/Cargo.toml
+++ b/example-crates/libc-replacement/Cargo.toml
@@ -13,9 +13,3 @@ libc = { path = "../../c-gull", features = ["coexist-with-libc"], package = "c-g
 
 # This is just an example crate, and not part of the c-ward workspace.
 [workspace]
-
-# TODO: Remove this workaround when
-# https://github.com/llvm/llvm-project/pull/105513
-# makes it into the Rust compiler.
-[profile.dev.package.unwinding]
-debug = false

--- a/example-crates/threadsafe-setenv/Cargo.toml
+++ b/example-crates/threadsafe-setenv/Cargo.toml
@@ -21,9 +21,3 @@ package = "c-gull"
 
 # This is just an example crate, and not part of the c-ward workspace.
 [workspace]
-
-# TODO: Remove this workaround when
-# https://github.com/llvm/llvm-project/pull/105513
-# makes it into the Rust compiler.
-[profile.dev.package.unwinding]
-debug = false

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-08-19"
+channel = "nightly-2024-10-01"
 components = ["rustc", "cargo", "rust-std", "rust-src", "rustfmt"]


### PR DESCRIPTION
Fix warnings about static mut variables, and remove the TODOs for the unwinding workaround.