### PR TITLE
Document that c-scape and c-gull depend on Nightly Rust.

### DIFF
--- a/c-gull/README.md
+++ b/c-gull/README.md
@@ -30,7 +30,7 @@ the significant functionality into independent crates with more Rust-idiomatic
 APIs, with c-gull just wrapping those APIs to implement the C ABIs.
 
 This is currently highly experimental, incomplete, and some things aren't
-optimized.
+optimized. And it depends on Nightly Rust.
 
 ## c-gull's two modes
 
@@ -43,8 +43,8 @@ requires some additional setup; see the [c-gull-example] example crate for
 more details.
 
 In "coexist-with-libc" mode, c-gull can be used as a drop-in (partial) libc
-replacement, provided you're using nightly Rust. To use it, just change your
-typical libc dependency in Cargo.toml to this:
+replacement. To use it, just change your typical libc dependency in Cargo.toml
+to this:
 
 ```toml
 libc = { version = "<c-gull version>", package = "c-gull", features = ["coexist-with-libc"] }

--- a/c-scape/README.md
+++ b/c-scape/README.md
@@ -17,10 +17,27 @@ c-scape is a layer underneath [c-gull]. It provides a subset of libc features,
 containing only features that don't require Rust's `std` to implement. This
 allows it to be used by `std` itself.
 
-Similar to c-gull, c-scape has "take-charge" and "coexist-with-libc" modes.
+This is currently highly experimental, incomplete, and some things aren't
+optimized. And it depends on Nightly Rust.
 
-"take-charge" mode requires some additional setup; see the [c-scape-example]
-example crate for more details.
+## c-scape's two modes
+
+[Similar to c-gull], c-scape has "take-charge" and "coexist-with-libc" modes.
+One of these must be enabled.
+
+In "take-charge" mode, c-scape takes charge of the process, handling program
+startup (via Origin) providing `malloc` (via c-scape), and other things. This
+requires some additional setup; see the [c-scape-example] example crate for
+more details.
+
+In "coexist-with-libc" mode, c-scape can be used as a drop-in (partial) libc
+replacement. To use it, just change your typical libc dependency in Cargo.toml
+to this:
+
+```toml
+libc = { version = "<c-scape version>", package = "c-scape", features = ["coexist-with-libc"] }
+```
 
 [c-gull]: https://github.com/sunfishcode/c-ward/tree/main/c-gull
 [c-scape-example]: https://github.com/sunfishcode/c-ward/blob/main/example-crates/c-scape-example
+[Similar to c-gull]: https://github.com/sunfishcode/c-ward/tree/main/c-gull#c-gulls-two-modes

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![no_std]
-#![feature(thread_local)] // for `__errno_location`
+#![feature(thread_local)] // for `pthread_getspecific` etc.
 #![feature(c_variadic)] // for `ioctl` etc.
 #![cfg_attr(feature = "use-compiler-builtins", feature(rustc_private))]
 #![feature(strict_provenance)]


### PR DESCRIPTION
Document that c-scape and c-gull depend on Nightly Rust in the README.md files.

And add more documentation about "take-charge" and "coexist-with-libc" mode to c-scape's README.md.

Fixes #144.