### PR TITLE
Update to printf-compat 0.2.1

### DIFF
--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -34,7 +34,7 @@ rand = { version = "0.9.0", default-features = false }
 rustix-dlmalloc = { version = "0.2.1", optional = true }
 rustix-openpty = "0.2.0"
 bitflags = { version = "2.4.1", default-features = false }
-printf-compat = { version = "0.1.1", default-features = false }
+printf-compat = { version = "0.2.1", default-features = false }
 num-complex = { version = "0.4.4", default-features = false, features = ["libm"] }
 posix-regex = { version = "0.1.1", features = ["no_std"] }
 


### PR DESCRIPTION
This fixes the build error:
```
error[E0277]: the trait bound `i8: VaArgSafe` is not satisfied
   --> /home/mateusz/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/printf-compat-0.1.1/src/parser.rs:80:50
    |
 80 |             Length::Char => SignedInt::Char(args.arg()),
    |                                                  ^^^ the trait `VaArgSafe` is not implemented for `i8`
    |
    = help: the following other types implement trait `VaArgSafe`:
              f64
              i32
              i64
              isize
              u32
              u64
              usize
```