### PR TITLE
fix compilation with new new nightly VaList

### DIFF
--- a/c-gull/src/nss.rs
+++ b/c-gull/src/nss.rs
@@ -305,10 +305,8 @@ unsafe fn getgr_r(
     };
     let pad = align_of::<*const c_char>() - (buf.addr()) % align_of::<*const c_char>();
     buf = buf.add(pad);
-    buflen -= pad;
     let gr_mem = buf.cast::<*mut c_char>();
     buf = gr_mem.add(num_members + 1).cast::<c_char>();
-    buflen -= buf.addr() - gr_mem.addr();
 
     let mut cur_mem = gr_mem;
     if num_members != 0 {
@@ -319,7 +317,6 @@ unsafe fn getgr_r(
             buf = buf.add(member.len());
             write(buf, 0);
             buf = buf.add(1);
-            buflen -= member.len() + 1;
         }
     }
     write(cur_mem, null_mut());

--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -34,7 +34,7 @@ rand = { version = "0.9.0", default-features = false }
 rustix-dlmalloc = { version = "0.2.1", optional = true }
 rustix-openpty = "0.2.0"
 bitflags = { version = "2.4.1", default-features = false }
-printf-compat = { version = "0.2.1", default-features = false }
+printf-compat = { version = "0.3.0", default-features = false }
 num-complex = { version = "0.4.4", default-features = false, features = ["libm"] }
 posix-regex = { version = "0.1.1", features = ["no_std"] }
 

--- a/c-scape/src/fs/fcntl.rs
+++ b/c-scape/src/fs/fcntl.rs
@@ -9,18 +9,16 @@ use libc::c_int;
 use crate::convert_res;
 
 #[no_mangle]
-unsafe extern "C" fn fcntl(fd: c_int, cmd: c_int, mut args: ...) -> c_int {
-    let args = args.as_va_list();
+unsafe extern "C" fn fcntl(fd: c_int, cmd: c_int, args: ...) -> c_int {
     _fcntl::<libc::flock>(fd, cmd, args)
 }
 
 #[no_mangle]
-unsafe extern "C" fn fcntl64(fd: c_int, cmd: c_int, mut args: ...) -> c_int {
-    let args = args.as_va_list();
+unsafe extern "C" fn fcntl64(fd: c_int, cmd: c_int, args: ...) -> c_int {
     _fcntl::<libc::flock64>(fd, cmd, args)
 }
 
-unsafe fn _fcntl<FlockTy: Flock>(fd: c_int, cmd: c_int, mut args: VaList<'_, '_>) -> c_int {
+unsafe fn _fcntl<FlockTy: Flock>(fd: c_int, cmd: c_int, mut args: VaList<'_>) -> c_int {
     match cmd {
         libc::F_GETFL => {
             libc!(libc::fcntl(fd, libc::F_GETFL));

--- a/c-scape/src/stdio.rs
+++ b/c-scape/src/stdio.rs
@@ -714,30 +714,24 @@ unsafe fn parse_oflags(mode: *const c_char) -> Option<OFlags> {
 }
 
 #[no_mangle]
-unsafe extern "C" fn printf(fmt: *const c_char, mut args: ...) -> c_int {
-    let va_list = args.as_va_list();
-    vprintf(fmt, va_list)
+unsafe extern "C" fn printf(fmt: *const c_char, args: ...) -> c_int {
+    vprintf(fmt, args)
 }
 
 #[no_mangle]
-unsafe extern "C" fn vprintf(fmt: *const c_char, va_list: VaList<'_, '_>) -> c_int {
+unsafe extern "C" fn vprintf(fmt: *const c_char, va_list: VaList<'_>) -> c_int {
     //libc!(libc::vprintf(fmt, va_list));
 
     vfprintf(stdout, fmt, va_list)
 }
 
 #[no_mangle]
-unsafe extern "C" fn sprintf(ptr: *mut c_char, fmt: *const c_char, mut args: ...) -> c_int {
-    let va_list = args.as_va_list();
-    vsprintf(ptr, fmt, va_list)
+unsafe extern "C" fn sprintf(ptr: *mut c_char, fmt: *const c_char, args: ...) -> c_int {
+    vsprintf(ptr, fmt, args)
 }
 
 #[no_mangle]
-unsafe extern "C" fn vsprintf(
-    ptr: *mut c_char,
-    fmt: *const c_char,
-    va_list: VaList<'_, '_>,
-) -> c_int {
+unsafe extern "C" fn vsprintf(ptr: *mut c_char, fmt: *const c_char, va_list: VaList<'_>) -> c_int {
     //libc!(libc::vsprintf(ptr, fmt, va_list));
 
     let mut out = String::new();
@@ -762,10 +756,9 @@ unsafe extern "C" fn snprintf(
     ptr: *mut c_char,
     len: usize,
     fmt: *const c_char,
-    mut args: ...
+    args: ...
 ) -> c_int {
-    let va_list = args.as_va_list();
-    vsnprintf(ptr, len, fmt, va_list)
+    vsnprintf(ptr, len, fmt, args)
 }
 
 #[no_mangle]
@@ -773,7 +766,7 @@ unsafe extern "C" fn vsnprintf(
     ptr: *mut c_char,
     len: usize,
     fmt: *const c_char,
-    va_list: VaList<'_, '_>,
+    va_list: VaList<'_>,
 ) -> c_int {
     //libc!(libc::vsnprintf(ptr, len, fmt, va_list));
 
@@ -797,13 +790,12 @@ unsafe extern "C" fn vsnprintf(
 }
 
 #[no_mangle]
-unsafe extern "C" fn dprintf(fd: c_int, fmt: *const c_char, mut args: ...) -> c_int {
-    let va_list = args.as_va_list();
-    vdprintf(fd, fmt, va_list)
+unsafe extern "C" fn dprintf(fd: c_int, fmt: *const c_char, args: ...) -> c_int {
+    vdprintf(fd, fmt, args)
 }
 
 #[no_mangle]
-unsafe extern "C" fn vdprintf(fd: c_int, fmt: *const c_char, va_list: VaList<'_, '_>) -> c_int {
+unsafe extern "C" fn vdprintf(fd: c_int, fmt: *const c_char, va_list: VaList<'_>) -> c_int {
     //libc!(libc::vdprintf(fd, fmt, va_list));
 
     let mut out = String::new();
@@ -830,16 +822,15 @@ unsafe extern "C" fn vdprintf(fd: c_int, fmt: *const c_char, va_list: VaList<'_,
 }
 
 #[no_mangle]
-unsafe extern "C" fn fprintf(file: *mut libc::FILE, fmt: *const c_char, mut args: ...) -> c_int {
-    let va_list = args.as_va_list();
-    vfprintf(file, fmt, va_list)
+unsafe extern "C" fn fprintf(file: *mut libc::FILE, fmt: *const c_char, args: ...) -> c_int {
+    vfprintf(file, fmt, args)
 }
 
 #[no_mangle]
 unsafe extern "C" fn vfprintf(
     file: *mut libc::FILE,
     fmt: *const c_char,
-    va_list: VaList<'_, '_>,
+    va_list: VaList<'_>,
 ) -> c_int {
     //libc!(libc::vfprintf(file, fmt, va_list));
 
@@ -858,9 +849,9 @@ unsafe extern "C" fn vfprintf(
 unsafe extern "C" fn vasprintf(
     strp: *mut *mut c_char,
     fmt: *const c_char,
-    va_list: VaList<'_, '_>,
+    va_list: VaList<'_>,
 ) -> c_int {
-    let len = va_list.with_copy(|va_list| vsnprintf(null_mut(), 0, fmt, va_list));
+    let len = vsnprintf(null_mut(), 0, fmt, va_list.clone());
     if len < 0 {
         return -1;
     }
@@ -875,9 +866,8 @@ unsafe extern "C" fn vasprintf(
 }
 
 #[no_mangle]
-unsafe extern "C" fn asprintf(strp: *mut *mut c_char, fmt: *const c_char, mut args: ...) -> c_int {
-    let va_list = args.as_va_list();
-    vasprintf(strp, fmt, va_list)
+unsafe extern "C" fn asprintf(strp: *mut *mut c_char, fmt: *const c_char, args: ...) -> c_int {
+    vasprintf(strp, fmt, args)
 }
 
 #[no_mangle]

--- a/c-scape/src/stdio/chk.rs
+++ b/c-scape/src/stdio/chk.rs
@@ -17,10 +17,9 @@ unsafe extern "C" fn __snprintf_chk(
     flag: c_int,
     slen: size_t,
     fmt: *const c_char,
-    mut args: ...
+    args: ...
 ) -> c_int {
-    let va_list = args.as_va_list();
-    __vsnprintf_chk(ptr, len, flag, slen, fmt, va_list)
+    __vsnprintf_chk(ptr, len, flag, slen, fmt, args)
 }
 
 // <https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib---vsnprintf-chk-1.html>
@@ -31,7 +30,7 @@ unsafe extern "C" fn __vsnprintf_chk(
     flag: c_int,
     slen: size_t,
     fmt: *const c_char,
-    va_list: VaList<'_, '_>,
+    va_list: VaList<'_>,
 ) -> c_int {
     if slen < len {
         __chk_fail();
@@ -51,10 +50,9 @@ unsafe extern "C" fn __sprintf_chk(
     flag: c_int,
     strlen: size_t,
     format: *const c_char,
-    mut args: ...
+    args: ...
 ) -> c_int {
-    let va_list = args.as_va_list();
-    __vsprintf_chk(ptr, flag, strlen, format, va_list)
+    __vsprintf_chk(ptr, flag, strlen, format, args)
 }
 
 #[no_mangle]
@@ -63,7 +61,7 @@ unsafe extern "C" fn __vsprintf_chk(
     flag: c_int,
     strlen: size_t,
     fmt: *const c_char,
-    va_list: VaList<'_, '_>,
+    va_list: VaList<'_>,
 ) -> c_int {
     if flag > 0 {
         unimplemented!("__USE_FORTIFY_LEVEL > 0");
@@ -88,10 +86,9 @@ unsafe extern "C" fn __fprintf_chk(
     file: *mut libc::FILE,
     flag: c_int,
     fmt: *const c_char,
-    mut args: ...
+    args: ...
 ) -> c_int {
-    let va_list = args.as_va_list();
-    __vfprintf_chk(file, flag, fmt, va_list)
+    __vfprintf_chk(file, flag, fmt, args)
 }
 
 // <https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib---vfprintf-chk-1.html>
@@ -100,7 +97,7 @@ unsafe extern "C" fn __vfprintf_chk(
     file: *mut libc::FILE,
     flag: c_int,
     fmt: *const c_char,
-    va_list: VaList<'_, '_>,
+    va_list: VaList<'_>,
 ) -> c_int {
     if flag > 0 {
         unimplemented!("__USE_FORTIFY_LEVEL > 0");
@@ -113,17 +110,12 @@ unsafe extern "C" fn __vfprintf_chk(
 
 // <https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib---printf-chk-1.html>
 #[no_mangle]
-unsafe extern "C" fn __printf_chk(flag: c_int, fmt: *const c_char, mut args: ...) -> c_int {
-    let va_list = args.as_va_list();
-    __vprintf_chk(flag, fmt, va_list)
+unsafe extern "C" fn __printf_chk(flag: c_int, fmt: *const c_char, args: ...) -> c_int {
+    __vprintf_chk(flag, fmt, args)
 }
 
 #[no_mangle]
-unsafe extern "C" fn __vprintf_chk(
-    flag: c_int,
-    fmt: *const c_char,
-    va_list: VaList<'_, '_>,
-) -> c_int {
+unsafe extern "C" fn __vprintf_chk(flag: c_int, fmt: *const c_char, va_list: VaList<'_>) -> c_int {
     if flag > 0 {
         unimplemented!("__USE_FORTIFY_LEVEL > 0");
     }
@@ -138,10 +130,9 @@ unsafe extern "C" fn __asprintf_chk(
     strp: *mut *mut c_char,
     flag: c_int,
     fmt: *const c_char,
-    mut args: ...
+    args: ...
 ) -> c_int {
-    let va_list = args.as_va_list();
-    __vasprintf_chk(strp, flag, fmt, va_list)
+    __vasprintf_chk(strp, flag, fmt, args)
 }
 
 #[no_mangle]
@@ -149,7 +140,7 @@ unsafe extern "C" fn __vasprintf_chk(
     strp: *mut *mut c_char,
     flag: c_int,
     fmt: *const c_char,
-    va_list: VaList<'_, '_>,
+    va_list: VaList<'_>,
 ) -> c_int {
     if flag > 0 {
         unimplemented!("__USE_FORTIFY_LEVEL > 0");
@@ -159,14 +150,8 @@ unsafe extern "C" fn __vasprintf_chk(
 }
 
 #[no_mangle]
-unsafe extern "C" fn __dprintf_chk(
-    fd: c_int,
-    flag: c_int,
-    fmt: *const c_char,
-    mut args: ...
-) -> c_int {
-    let va_list = args.as_va_list();
-    __vdprintf_chk(fd, flag, fmt, va_list)
+unsafe extern "C" fn __dprintf_chk(fd: c_int, flag: c_int, fmt: *const c_char, args: ...) -> c_int {
+    __vdprintf_chk(fd, flag, fmt, args)
 }
 
 #[no_mangle]
@@ -174,7 +159,7 @@ unsafe extern "C" fn __vdprintf_chk(
     fd: c_int,
     flag: c_int,
     fmt: *const c_char,
-    va_list: VaList<'_, '_>,
+    va_list: VaList<'_>,
 ) -> c_int {
     if flag > 0 {
         unimplemented!("__USE_FORTIFY_LEVEL > 0");

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-04-28"
+channel = "nightly-2025-12-07"
 components = ["rustc", "cargo", "rust-std", "rust-src", "rustfmt"]


### PR DESCRIPTION
In 2025-12-05, a Rust pull request at https://github.com/rust-lang/rust/pull/141980 reworked the `VaList` implementation to be abi-compatible with C. This broke:

  * the `printf-compat` implementation, which is fixed in version 0.3
  * some `fcntl` functions, because they called `as_va_list`, and that function no longer exists

Here, we fix both of those problems and update the compiler version in `rust-toolchain.toml` to be the oldest compiler that will already have this new implementation.

---

Fixes #164