### PR TITLE
tests: Remove invalid `target_env` cfg

### DIFF
--- a/tests/example_crates.rs
+++ b/tests/example_crates.rs
@@ -23,8 +23,6 @@ fn test_crate(
     let arch = "i686";
     #[cfg(target_arch = "arm")]
     let arch = "armv5te";
-    #[cfg(target_env = "gnueabi")]
-    let env = "gnueabi";
     #[cfg(all(target_env = "gnu", target_abi = "eabi"))]
     let env = "gnueabi";
     #[cfg(all(target_env = "gnu", not(target_abi = "eabi")))]


### PR DESCRIPTION
When looking at the CI test logs, there is this warning emitted:

```rust
warning: unexpected `cfg` condition value: `gnueabi`
  --> tests/example_crates.rs:26:11
   |
26 |     #[cfg(target_env = "gnueabi")]
   |           ^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: expected values for `target_env` are: ``, `gnu`, `macabi`, `mlibc`, `msvc`, `musl`, `newlib`, `nto70`, `nto71`, `nto71_iosock`, `nto80`, `ohos`, `p1`, `p2`, `p3`, `relibc`, `sgx`, `sim`, `uclibc`, and `v5`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
   = note: `#[warn(unexpected_cfgs)]` on by default
```

Associated section:

https://github.com/sunfishcode/c-ward/blob/f71902a0032ca0f42d3af376d7a820b2831e7ca7/tests/example_crates.rs#L26-L31

These were [added in Sep 2023](https://github.com/sunfishcode/c-ward/commit/c14239e3fe239ac9503518befcd30739bbbfccc4) and accompanied with a feature gate [`#![feature(cfg_target_abi)]`](https://github.com/rust-lang/rust/issues/80970) (_which [stabilized in Rust 1.78.0](https://github.com/rust-lang/rust/pull/119590) in May 2024, [related discussion](https://internals.rust-lang.org/t/expand-targets-acceptable-to-rustc/14885/29)_) that was [dropped in from `tests/example_crates.rs` in March 2024](https://github.com/sunfishcode/c-ward/pull/123) as part of the nightly version bump.