### PR TITLE
ci: Prevent matrix jobs relying on QEMU from cancelling other jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,9 @@ jobs:
   test:
     name: Test
     runs-on: ${{ matrix.os }}
+    # Test jobs running with QEMU could potentially fail due to the use of QEMU,
+    # prevent such failures from cancelling non-QEMU jobs.
+    continue-on-error: ${{ matrix.qemu == '' }}
     env:
       QEMU_BUILD_VERSION: 8.1.0
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,12 +18,11 @@ jobs:
   test:
     name: Test
     runs-on: ${{ matrix.os }}
-    # Test jobs running with QEMU could potentially fail due to the use of QEMU,
-    # prevent such failures from cancelling non-QEMU jobs.
-    continue-on-error: ${{ matrix.qemu == '' }}
     env:
       QEMU_BUILD_VERSION: 8.1.0
     strategy:
+      # Don't cancel other test jobs if one test fails (which in some cases may be caused by QEMU)
+      fail-fast: false
       matrix:
         build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux]
         include:


### PR DESCRIPTION
Related: https://github.com/sunfishcode/c-ward/issues/170

---

This change should safeguard against the `aarch64`/`riscv64` QEMU targets triggering a failure on the `x86_64`/`i686` non-QEMU targets.
- A recent run had cancelled the `i686` target, I'm not sure how likely it would be for the `x86_64` target job to be cancelled.
- I have observed that pull request test runs were not introducing such failures, while commits pushed to main (including merged PRs) were. PRs can inherit cache from the main branch, but not the other way around. Doesn't seem to be relevant as [this step that restores QEMU cache](https://github.com/sunfishcode/c-ward/blob/v0.22.3/.github/workflows/main.yml#L61-L65) (_if not expired/evicted_) was not successful at finding cache in any of the referenced CI runs.

---

**EDIT:** Switched to [`fail-fast: false`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategyfail-fast) instead of `continue-on-error: <condition>` (_which may not propagate the failure of a test job_).

A better use of resources would be to run the native target on the runner first, then have the matrix for other targets that rely upon QEMU to depend on the first target passing. However you'd still get a similar issue of one QEMU reliant job failure canceling the others without a change like this.

`fail-fast: false` should ensure that all matrix jobs run to completion without triggering a cancel to all other matrix jobs when encountering a failure. That should then still communicate a failure of the workflow, but without the canceled jobs.

If the failure is related to QEMU, there isn't much we can easily do to differentiate that from the project's own tests failing which I assume still have some relevance 😅 