### PR TITLE
fix: Support Nightly newer than `nightly-2026-04-23`

### DIFF
--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -34,7 +34,7 @@ rand = { version = "0.9.0", default-features = false }
 rustix-dlmalloc = { version = "0.2.1", optional = true }
 rustix-openpty = "0.2.0"
 bitflags = { version = "2.4.1", default-features = false }
-printf-compat = { version = "0.3.0", default-features = false }
+printf-compat = { version = "0.4.0", default-features = false }
 num-complex = { version = "0.4.4", default-features = false, features = ["libm"] }
 posix-regex = { version = "0.1.1", features = ["no_std"] }
 

--- a/c-scape/src/fs/fcntl.rs
+++ b/c-scape/src/fs/fcntl.rs
@@ -29,7 +29,7 @@ unsafe fn _fcntl<FlockTy: Flock>(fd: c_int, cmd: c_int, mut args: VaList<'_>) ->
             }
         }
         libc::F_SETFL => {
-            let flags = args.arg::<c_int>();
+            let flags = args.next_arg::<c_int>();
             libc!(libc::fcntl(fd, libc::F_SETFL, flags));
             let fd = BorrowedFd::borrow_raw(fd);
             match convert_res(rustix::fs::fcntl_setfl(
@@ -49,7 +49,7 @@ unsafe fn _fcntl<FlockTy: Flock>(fd: c_int, cmd: c_int, mut args: VaList<'_>) ->
             }
         }
         libc::F_SETFD => {
-            let flags = args.arg::<c_int>();
+            let flags = args.next_arg::<c_int>();
             libc!(libc::fcntl(fd, libc::F_SETFD, flags));
             let fd = BorrowedFd::borrow_raw(fd);
             match convert_res(rustix::io::fcntl_setfd(
@@ -61,7 +61,7 @@ unsafe fn _fcntl<FlockTy: Flock>(fd: c_int, cmd: c_int, mut args: VaList<'_>) ->
             }
         }
         libc::F_SETLK | libc::F_SETLKW => {
-            let ptr = args.arg::<*mut FlockTy>();
+            let ptr = args.next_arg::<*mut FlockTy>();
             libc!(libc::fcntl(fd, cmd, ptr));
             let fd = BorrowedFd::borrow_raw(fd);
             let is_blocking = cmd == libc::F_SETLKW;
@@ -96,7 +96,7 @@ unsafe fn _fcntl<FlockTy: Flock>(fd: c_int, cmd: c_int, mut args: VaList<'_>) ->
         }
         #[cfg(not(target_os = "wasi"))]
         libc::F_DUPFD_CLOEXEC => {
-            let arg = args.arg::<c_int>();
+            let arg = args.next_arg::<c_int>();
             libc!(libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, arg));
             let fd = BorrowedFd::borrow_raw(fd);
             match convert_res(rustix::io::fcntl_dupfd_cloexec(fd, arg)) {

--- a/c-scape/src/fs/open.rs
+++ b/c-scape/src/fs/open.rs
@@ -14,7 +14,7 @@ macro_rules! openat_impl {
     ($fd:expr, $pathname:ident, $flags:ident, $args:ident) => {{
         let flags = OFlags::from_bits($flags as _).unwrap();
         let mode = if flags.contains(OFlags::CREATE) || flags.contains(OFlags::TMPFILE) {
-            let mode: libc::mode_t = $args.arg();
+            let mode: libc::mode_t = $args.next_arg();
             Mode::from_bits((mode & !libc::S_IFMT) as _).unwrap()
         } else {
             Mode::empty()

--- a/c-scape/src/io/mod.rs
+++ b/c-scape/src/io/mod.rs
@@ -33,14 +33,14 @@ unsafe extern "C" fn ioctl(fd: c_int, request: c_long, mut args: ...) -> c_int {
             let fd = BorrowedFd::borrow_raw(fd);
             match convert_res(rustix::termios::tcgetattr(fd)) {
                 Some(x) => {
-                    args.arg::<*mut rustix::termios::Termios>().write(x);
+                    args.next_arg::<*mut rustix::termios::Termios>().write(x);
                     0
                 }
                 None => -1,
             }
         }
         FIONBIO | TIOCINQ => {
-            let ptr = args.arg::<*mut c_int>();
+            let ptr = args.next_arg::<*mut c_int>();
             let value = *ptr != 0;
             libc!(libc::ioctl(fd, libc::FIONBIO, value as c_int));
             let fd = BorrowedFd::borrow_raw(fd);
@@ -60,14 +60,14 @@ unsafe extern "C" fn ioctl(fd: c_int, request: c_long, mut args: ...) -> c_int {
                         ws_xpixel: size.ws_xpixel,
                         ws_ypixel: size.ws_ypixel,
                     };
-                    args.arg::<*mut libc::winsize>().write(size);
+                    args.next_arg::<*mut libc::winsize>().write(size);
                     0
                 }
                 None => -1,
             }
         }
         FICLONE => {
-            let src_fd = args.arg::<c_int>();
+            let src_fd = args.next_arg::<c_int>();
             libc!(libc::ioctl(fd, libc::FICLONE as _, src_fd));
             let fd = BorrowedFd::borrow_raw(fd);
             let src_fd = BorrowedFd::borrow_raw(src_fd);

--- a/c-scape/src/mm/mod.rs
+++ b/c-scape/src/mm/mod.rs
@@ -77,7 +77,7 @@ unsafe extern "C" fn mremap(
     mut args: ...
 ) -> *mut c_void {
     if (flags & libc::MREMAP_FIXED) == libc::MREMAP_FIXED {
-        let new_address = args.arg::<*mut c_void>();
+        let new_address = args.next_arg::<*mut c_void>();
         libc!(libc::mremap(
             old_address,
             old_size,

--- a/c-scape/src/process/exec.rs
+++ b/c-scape/src/process/exec.rs
@@ -19,7 +19,7 @@ unsafe extern "C" fn execl(path: *const c_char, arg: *const c_char, mut argv: ..
     vec.push(arg);
 
     loop {
-        let ptr = argv.arg::<*const c_char>();
+        let ptr = argv.next_arg::<*const c_char>();
         vec.push(ptr);
         if ptr.is_null() {
             break;
@@ -35,10 +35,10 @@ unsafe extern "C" fn execle(path: *const c_char, arg: *const c_char, mut argv: .
     vec.push(arg);
 
     let envp = loop {
-        let ptr = argv.arg::<*const c_char>();
+        let ptr = argv.next_arg::<*const c_char>();
         vec.push(ptr);
         if ptr.is_null() {
-            break argv.arg::<*const *const c_char>();
+            break argv.next_arg::<*const *const c_char>();
         }
     };
 
@@ -51,7 +51,7 @@ unsafe extern "C" fn execlp(file: *const c_char, arg: *const c_char, mut argv: .
     vec.push(arg);
 
     loop {
-        let ptr = argv.arg::<*const c_char>();
+        let ptr = argv.next_arg::<*const c_char>();
         vec.push(ptr);
         if ptr.is_null() {
             break;

--- a/c-scape/src/syscall.rs
+++ b/c-scape/src/syscall.rs
@@ -79,19 +79,19 @@ unsafe extern "C" fn syscall(number: c_long, mut args: ...) -> *mut c_void {
             without_provenance_mut(libc::statx(dirfd, path, flags, mask, statxbuf) as _)
         }
         libc::SYS_getrandom => {
-            let buf = args.arg::<*mut c_void>();
-            let len = args.arg::<usize>();
-            let flags = args.arg::<u32>();
+            let buf = args.next_arg::<*mut c_void>();
+            let len = args.next_arg::<usize>();
+            let flags = args.next_arg::<u32>();
             without_provenance_mut(libc::getrandom(buf, len, flags) as _)
         }
         #[cfg(feature = "thread")]
         libc::SYS_futex => {
-            let uaddr = args.arg::<*mut u32>();
-            let futex_op = args.arg::<c_int>();
-            let val = args.arg::<u32>();
-            let timeout = args.arg::<*const libc::timespec>();
-            let uaddr2 = args.arg::<*mut u32>();
-            let val3 = args.arg::<u32>();
+            let uaddr = args.next_arg::<*mut u32>();
+            let futex_op = args.next_arg::<c_int>();
+            let val = args.next_arg::<u32>();
+            let timeout = args.next_arg::<*const libc::timespec>();
+            let uaddr2 = args.next_arg::<*mut u32>();
+            let val3 = args.next_arg::<u32>();
             without_provenance_mut(
                 futex(uaddr, futex_op, val, timeout, uaddr2, val3) as isize as usize
             )

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-12-07"
+channel = "nightly-2026-06-11"
 components = ["rustc", "cargo", "rust-std", "rust-src", "rustfmt"]


### PR DESCRIPTION
- `nightly-2026-04-24` => Fixed with `printf-compat@0.4.0`
- `nightly-2026-05-30` => Fixed with `unwinding@<unreleased>`

---

In April 2026 [Nightly changes](https://github.com/rust-lang/rust/pull/155614) have introduced breaking changes that require [`printf-compat@0.4.0`](https://github.com/lights0123/printf-compat/blob/master/CHANGELOG.md#040-april-26-2026) to be compatible for compiling `c-scape` with.

Besides bumping the dependency version, there is a slight API change of [`.arg()` to `.next_arg()`](https://github.com/lights0123/printf-compat/commit/c8cdff509b29231e9159f6b485ecc8d3f543df04).