### PR TITLE
tests(fix): Exclude unused features from failing a test

### DIFF
--- a/tests/example_crates.rs
+++ b/tests/example_crates.rs
@@ -56,7 +56,9 @@ fn example_crate_libc_replacement() {
         )
     });
 
-    test_crate("libc-replacement", &[], &[], &expected, "", None);
+    // Prevent unused features (thread_local + linkage) from producing warnings to stderr:
+    let envs = &[("RUSTFLAGS", "-A unused_features")];
+    test_crate("libc-replacement", &[], envs, &expected, "", None);
 }
 
 #[test]
@@ -154,8 +156,6 @@ fn example_crate_c_gull_unwinding() {
     let arch = "i686";
     #[cfg(target_arch = "arm")]
     let arch = "armv5te";
-    #[cfg(target_env = "gnueabi")]
-    let env = "gnueabi";
     #[cfg(all(target_env = "gnu", target_abi = "eabi"))]
     let env = "gnueabi";
     #[cfg(all(target_env = "gnu", not(target_abi = "eabi")))]


### PR DESCRIPTION
This resolves a current test failure (_[CI failure log](https://github.com/sunfishcode/c-ward/actions/runs/27576005726/job/81524385483#step:8:162)_) caused by lint warnings emitted to stderr due to (_introduced from the [recent Nightly version bump](https://github.com/sunfishcode/c-ward/pull/173)_):
- A new lint `unused_features` was introduced in a March 2026 Nightly release (_and later part of Rust 1.96_): https://github.com/rust-lang/rust/pull/152164
- A follow-up in March 2026 adjusted the scope of the lint to unstable features: https://github.com/rust-lang/rust/pull/153610

I am not sure how you'd like to approach resolving this.
- I chose to only apply it to the affected test case rather than globally within `c-scape/src/lib.rs` by adding a `#![allow(unused_features)]`.
- Another alternative would be to expect the stderr output instead with the lint warnings.

<details>
<summary>CI test failure output (click to expand)</summary>

[CI failure log](https://github.com/sunfishcode/c-ward/actions/runs/27576005726/job/81524385483#step:8:162), relevant snippet:

````rust
     Running tests/example_crates.rs (target/debug/deps/example_crates-4423017ae3c0b04a)

running 12 tests
test example_crate_c_gull_example_panic_abort ... ok
test example_crate_c_gull_unwinding ... ok
test example_crate_c_gull_example ... ok
test example_crate_c_scape_example ... ok
test example_crate_c_scape_example_panic_abort ... ok
test example_crate_c_scape_unwinding ... ok
test example_crate_c_gull_lto ... ok
test example_crate_custom_allocator ... ok
test example_crate_libc_replacement ... FAILED
test example_crate_dns ... ok
test example_crate_threadsafe_setenv_lookup ... ok
test example_crate_threadsafe_setenv_getenv ... ok

failures:

---- example_crate_libc_replacement stdout ----

thread 'example_crate_libc_replacement' (9924) panicked at tests/example_crates.rs:39:40:
Unexpected stderr, failed diff original var
├── original: 
├── diff: 
│   --- 	orig
│   +++ 	var
│   @@ -0,0 +1,14 @@
│   +warning: feature `thread_local` is declared but not used
│   + --> /home/runner/work/c-ward/c-ward/c-scape/src/lib.rs:5:12
│   +  |
│   +5 | #![feature(thread_local)] // for `pthread_getspecific` etc.
│   +  |            ^^^^^^^^^^^^
│   +  |
│   +  = note: `#[warn(unused_features)]` (part of `#[warn(unused)]`) on by default
│   +
│   +warning: feature `linkage` is declared but not used
│   + --> /home/runner/work/c-ward/c-ward/c-scape/src/lib.rs:8:12
│   +  |
│   +8 | #![feature(linkage)] // for `malloc` etc.
│   +  |            ^^^^^^^
│   +
└── var as str: warning: feature `thread_local` is declared but not used
     --> /home/runner/work/c-ward/c-ward/c-scape/src/lib.rs:5:12
      |
    5 | #![feature(thread_local)] // for `pthread_getspecific` etc.
      |            ^^^^^^^^^^^^
      |
      = note: `#[warn(unused_features)]` (part of `#[warn(unused)]`) on by default
    
    warning: feature `linkage` is declared but not used
     --> /home/runner/work/c-ward/c-ward/c-scape/src/lib.rs:8:12
      |
    8 | #![feature(linkage)] // for `malloc` etc.
      |            ^^^^^^^
    

command=`cd "example-crates/libc-replacement" && "cargo" "run" "--quiet" "--target=x86_64-unknown-linux-gnu"`
code=0
stdout=```
Hello, world! uid=1001
Hello world with printf! gid=1001
Hello world from `atexit_func`
```

stderr=```
warning: feature `thread_local` is declared but not used
 --> /home/runner/work/c-ward/c-ward/c-scape/src/lib.rs:5:12
  |
5 | #![feature(thread_local)] // for `pthread_getspecific` etc.
  |            ^^^^^^^^^^^^
  |
  = note: `#[warn(unused_features)]` (part of `#[warn(unused)]`) on by default

warning: feature `linkage` is declared but not used
 --> /home/runner/work/c-ward/c-ward/c-scape/src/lib.rs:8:12
  |
8 | #![feature(linkage)] // for `malloc` etc.
  |            ^^^^^^^

```
````

</details>

---

Separately within this same file is a removal that was missed as part of [PR `#169`](https://github.com/sunfishcode/c-ward/pull/169), which didn't cause any failures but does removal a warning (_as per referenced PR_).