### PR TITLE
chore: `c-scape` - Remove conditional for riscv64 in `malloc()`

### DIFF
--- a/c-scape/src/malloc/mod.rs
+++ b/c-scape/src/malloc/mod.rs
@@ -3,7 +3,6 @@
 //! TODO: Use `alloc_zeroed` and `realloc` instead of doing the work
 //! ourselves, which might let allocators be more efficient.
 
-#[cfg(not(target_arch = "riscv64"))]
 use core::mem::align_of;
 use core::mem::size_of;
 use core::ptr::{copy_nonoverlapping, null_mut, write_bytes};
@@ -107,10 +106,6 @@ unsafe extern "C" fn malloc(size: usize) -> *mut c_void {
     // wild interprets NULL as an allocation failure.
     let size = if size == 0 { size + 1 } else { size };
 
-    // TODO: Add `max_align_t` for riscv64 to upstream libc.
-    #[cfg(target_arch = "riscv64")]
-    let layout = alloc::alloc::Layout::from_size_align(size, 16);
-    #[cfg(not(target_arch = "riscv64"))]
     let layout = alloc::alloc::Layout::from_size_align(size, align_of::<libc::max_align_t>());
 
     let layout = match layout {


### PR DESCRIPTION
This TODO item was [resolved upstream with `libc` in March 2026](https://github.com/rust-lang/libc/pull/5029) (_published as [`libc@0.2.184`](https://github.com/rust-lang/libc/releases/tag/0.2.184) on April 2nd 2026_).

**NOTE:** CI will fail until merging the fix I raised earlier: https://github.com/sunfishcode/c-ward/pull/174

<details>
<summary>Reference - CI failure log</summary>

````
failures:

---- example_crate_libc_replacement stdout ----

thread 'example_crate_libc_replacement' (10085) panicked at tests/example_crates.rs:39:40:
Unexpected stderr, failed diff original var
├── original: 
├── diff: 
│   --- 	orig
│   +++ 	var
│   @@ -0,0 +1,14 @@
│   +warning: feature `thread_local` is declared but not used
│   + --> /home/runner/work/c-ward/c-ward/c-scape/src/lib.rs:5:12
│   +  |
│   +5 | #![feature(thread_local)] // for `pthread_getspecific` etc.
│   +  |            ^^^^^^^^^^^^
│   +  |
│   +  = note: `#[warn(unused_features)]` (part of `#[warn(unused)]`) on by default
│   +
│   +warning: feature `linkage` is declared but not used
│   + --> /home/runner/work/c-ward/c-ward/c-scape/src/lib.rs:8:12
│   +  |
│   +8 | #![feature(linkage)] // for `malloc` etc.
│   +  |            ^^^^^^^
│   +
└── var as str: warning: feature `thread_local` is declared but not used
     --> /home/runner/work/c-ward/c-ward/c-scape/src/lib.rs:5:12
      |
    5 | #![feature(thread_local)] // for `pthread_getspecific` etc.
      |            ^^^^^^^^^^^^
      |
      = note: `#[warn(unused_features)]` (part of `#[warn(unused)]`) on by default
    
    warning: feature `linkage` is declared but not used
     --> /home/runner/work/c-ward/c-ward/c-scape/src/lib.rs:8:12
      |
    8 | #![feature(linkage)] // for `malloc` etc.
      |            ^^^^^^^
    

command=`cd "example-crates/libc-replacement" && "cargo" "run" "--quiet" "--target=x86_64-unknown-linux-gnu"`
code=0
stdout=```
Hello, world! uid=1001
Hello world with printf! gid=1001
Hello world from `atexit_func`
```

stderr=```
warning: feature `thread_local` is declared but not used
 --> /home/runner/work/c-ward/c-ward/c-scape/src/lib.rs:5:12
  |
5 | #![feature(thread_local)] // for `pthread_getspecific` etc.
  |            ^^^^^^^^^^^^
  |
  = note: `#[warn(unused_features)]` (part of `#[warn(unused)]`) on by default

warning: feature `linkage` is declared but not used
 --> /home/runner/work/c-ward/c-ward/c-scape/src/lib.rs:8:12
  |
8 | #![feature(linkage)] // for `malloc` etc.
  |            ^^^^^^^

```


stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/485ec3fbcc12fa14ef6596dabb125ad710499c9e/library/std/src/panicking.rs:678:5
   1: core::panicking::panic_fmt
             at /rustc/485ec3fbcc12fa14ef6596dabb125ad710499c9e/library/core/src/panicking.rs:80:14
   2: core::panicking::panic_display::<assert_cmd::assert::AssertError>
             at /home/runner/.rustup/toolchains/nightly-2026-06-11-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panicking.rs:259:5
   3: <assert_cmd::assert::AssertError>::panic::<assert_cmd::assert::Assert>
             at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/assert_cmd-2.2.2/src/assert.rs:1061:9
   4: <assert_cmd::assert::Assert>::stderr::<&str, assert_cmd::assert::StrContentOutputPredicate>
             at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/assert_cmd-2.2.2/src/assert.rs:487:25
   5: example_crates::test_crate
             at ./tests/example_crates.rs:39:40
   6: example_crates::example_crate_libc_replacement
             at ./tests/example_crates.rs:59:5
   7: example_crates::example_crate_libc_replacement::{closure#0}
             at ./tests/example_crates.rs:48:36
   8: <example_crates::example_crate_libc_replacement::{closure#0} as core::ops::function::FnOnce<()>>::call_once
             at /home/runner/.rustup/toolchains/nightly-2026-06-11-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
   9: <fn() -> core::result::Result<(), alloc::string::String> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/485ec3fbcc12fa14ef6596dabb125ad710499c9e/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.


failures:
    example_crate_libc_replacement

test result: FAILED. 11 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 75.69s

error: test failed, to rerun pass `-p c-ward --test example_crates`
Error: Process completed with exit code 101.
````

</details>